### PR TITLE
Bug: `set` fails when an `ex` parameter is provided

### DIFF
--- a/test/tests.ts
+++ b/test/tests.ts
@@ -12,6 +12,13 @@ test("create client from node_redis", async t => {
     t.truthy(await client.ping());
 });
 
+test("set", async t => {
+  const client = createHandyClient();
+
+  await client.set("a:foo", "123", 60);
+  t.deepEqual(await client.ttl("a:foo"), 60);
+})
+
 test("keys", async t => {
     const client = createHandyClient();
 


### PR DESCRIPTION
The type signature for `set` includes an `EX` parameter:

```typescript
    set(key: string, value: string, EX_seconds: number): Promise<string>;
```

But this generates an invalid redis call, because it sends `SET key value 1234` instead of `SET key value EX 1234`.

This PR includes a currently failing test.