### PR TITLE
Upgrade redis types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -607,8 +607,7 @@
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-      "dev": true
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/glob": {
       "version": "5.0.35",
@@ -636,22 +635,15 @@
     "@types/node": {
       "version": "7.0.69",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
-      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
-      "dev": true
+      "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw=="
     },
     "@types/redis": {
-      "version": "0.12.36",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-0.12.36.tgz",
-      "integrity": "sha1-Yd9lKiaa9CX+Lp7pXN+hdVd7TDs=",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.6.tgz",
+      "integrity": "sha512-kaSI4XQwCfJtPiuyCXvLxCaw2N0fMZesdob3Jh01W20vNFct+3lfvJ/4yCJxbSopXOBOzpg+pGxkW6uWZrPZHA==",
       "requires": {
+        "@types/events": "*",
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.53",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-          "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ=="
-        }
       }
     },
     "@types/shelljs": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "@types/redis": "^0.12.36",
+    "@types/redis": "^2.8.6",
     "redis": "^2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When accessing the base `RedisClient` in Typescript using

    import { createHandyClient } from 'handy-redis';

    const handyClient = createHandyClient(6379, "redis");
    const redisClient: RedisClient = handyClient.redis;

The current redis types`0.12.36` prevent the use of some commands, including `batch()`.

Upgrading the redis types to `2.8.6` fixes this issue