### PR TITLE
fix(flatten): avoid exceeding maximum call stack size

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
   },
   "homepage": "https://github.com/mmkal/handy-redis#readme",
   "jest": {
+    "globals": {
+      "ts-jest": {
+        "diagnostics": false
+      }
+    },
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,7 +1,10 @@
 export const flattenDeep = (array: any[]): any[]  => {
     const flat = [] as any[];
     for (const item of array) {
-        Array.isArray(item) ? flat.push(...flattenDeep(item)) : flat.push(item);
+      const values = Array.isArray(item) ? flattenDeep(item) : [item];
+      for (const val of values) {
+        flat.push(val);
+      }
     }
     return flat;
 };

--- a/test/flatten.test.ts
+++ b/test/flatten.test.ts
@@ -1,5 +1,5 @@
 import { flattenDeep } from "../src/flatten";
-import {range} from "lodash";
+import {range, isEqual} from "lodash";
 
 it("is already flat", () => {
     expect(flattenDeep([1, 2, 3])).toEqual([1, 2, 3]);
@@ -15,5 +15,10 @@ it("flattens deeply", () => {
 
 it("flattens huge arrays", () => {
     const huge = range(0, 500000);
-    expect(flattenDeep(huge)).toEqual(huge);
+    expect(isEqual(flattenDeep(huge), huge)).toBe(true);
+});
+
+it("flattens huge nested arrays", () => {
+    const huge = [[[[[range(0, 500000)]]]]];
+    expect(isEqual(flattenDeep(huge), huge[0][0][0][0][0])).toBe(true);
 });


### PR DESCRIPTION
fixes the new case identified in https://github.com/mmkal/handy-redis/issues/108 by avoiding the spread operator completely

note: the switch from `expect(...).toEqual(...)` to `expect(isEqual(..., ...)).toBe(true)` is because my terminal couldn't handle the size of the error messages when the test failed.