### PR TITLE
test: fix redis docker version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 redis:
-  image: redis
+  image: redis:6.0.4
   container_name: handy_redis
   ports:
     - "6379:6379"

--- a/test/generated/commands/__snapshots__/command-info.test.ts.snap
+++ b/test/generated/commands/__snapshots__/command-info.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`scripts/redis-doc/commands/command-info.md example 1 1`] = `
 Array [
-  "await client.command('INFO', 'get', 'set', 'eval')               => [['get',2,['readonly','fast'],1,1,1],['set',-3,['write','denyoom'],1,1,1],['eval',-3,['noscript','movablekeys'],0,0,0]]",
-  "await client.command('INFO', 'foo', 'evalsha', 'config', 'bar')  => [null,['evalsha',-3,['noscript','movablekeys'],0,0,0],['config',-2,['admin','noscript','loading','stale'],0,0,0],null]",
+  "await client.command('INFO', 'get', 'set', 'eval')               => [['get',2,['readonly','fast'],1,1,1,['@read','@string','@fast']],['set',-3,['write','denyoom'],1,1,1,['@write','@string','@slow']],['eval',-3,['noscript','movablekeys'],0,0,0,['@slow','@scripting']]]",
+  "await client.command('INFO', 'foo', 'evalsha', 'config', 'bar')  => [null,['evalsha',-3,['noscript','movablekeys'],0,0,0,['@slow','@scripting']],['config',-2,['admin','noscript','loading','stale'],0,0,0,['@admin','@slow','@dangerous']],null]",
 ]
 `;


### PR DESCRIPTION
Using `image: redis` in docker-compose meant the output from `command-info` changed silently. This pins the library to test against a specific redis version (latest as of today).