### PR TITLE
fix: allow +inf,-inf, ranges in interval args (redis-doc workaround)

### DIFF
--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -5357,13 +5357,37 @@
             {
                 "name": "min",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             },
             {
                 "name": "max",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             }
         ],
@@ -5792,13 +5816,37 @@
             {
                 "name": "min",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             },
             {
                 "name": "max",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             },
             {
@@ -5972,13 +6020,37 @@
             {
                 "name": "min",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             },
             {
                 "name": "max",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             }
         ],
@@ -6041,13 +6113,37 @@
             {
                 "name": "max",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             },
             {
                 "name": "min",
                 "schema": {
-                    "type": "number"
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["-inf", "+inf"]
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\(\\d+(\\.\\d+)?$"
+                        }
+                    ]
                 }
             },
             {

--- a/src/generated/interface.ts
+++ b/src/generated/interface.ts
@@ -6986,7 +6986,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zcount)
      */
-    zcount(key: string, min: number, max: number): Promise<number>;
+    zcount(
+        key: string,
+        min: number | ("-inf" | "+inf") | string,
+        max: number | ("-inf" | "+inf") | string
+    ): Promise<number>;
 
     /**
      * Increment the score of a member in a sorted set
@@ -7165,8 +7169,8 @@ export interface Commands {
      */
     zrangebyscore(
         key: string,
-        min: number,
-        max: number,
+        min: number | ("-inf" | "+inf") | string,
+        max: number | ("-inf" | "+inf") | string,
         limit_offset_count?: ["LIMIT", [number, number]]
     ): Promise<Array<string>>;
 
@@ -7180,8 +7184,8 @@ export interface Commands {
      */
     zrangebyscore(
         key: string,
-        min: number,
-        max: number,
+        min: number | ("-inf" | "+inf") | string,
+        max: number | ("-inf" | "+inf") | string,
         withscores?: "WITHSCORES",
         limit_offset_count?: ["LIMIT", [number, number]]
     ): Promise<Array<string>>;
@@ -7234,7 +7238,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zremrangebyscore)
      */
-    zremrangebyscore(key: string, min: number, max: number): Promise<number>;
+    zremrangebyscore(
+        key: string,
+        min: number | ("-inf" | "+inf") | string,
+        max: number | ("-inf" | "+inf") | string
+    ): Promise<number>;
 
     /**
      * Return a range of members in a sorted set, by index, with scores ordered from high to low
@@ -7256,8 +7264,8 @@ export interface Commands {
      */
     zrevrangebyscore(
         key: string,
-        max: number,
-        min: number,
+        max: number | ("-inf" | "+inf") | string,
+        min: number | ("-inf" | "+inf") | string,
         limit_offset_count?: ["LIMIT", [number, number]]
     ): Promise<Array<unknown>>;
 
@@ -7271,8 +7279,8 @@ export interface Commands {
      */
     zrevrangebyscore(
         key: string,
-        max: number,
-        min: number,
+        max: number | ("-inf" | "+inf") | string,
+        min: number | ("-inf" | "+inf") | string,
         withscores?: "WITHSCORES",
         limit_offset_count?: ["LIMIT", [number, number]]
     ): Promise<Array<unknown>>;

--- a/test/generated/commands/zcount.test.ts
+++ b/test/generated/commands/zcount.test.ts
@@ -25,6 +25,8 @@ test("docs/redis-doc/commands/zcount.md example 1", async () => {
           "r0": 1,
           "r1": 1,
           "r2": 1,
+          "r3": 3,
+          "r4": 2,
         }
     `);
 });

--- a/test/generated/commands/zcount.test.ts
+++ b/test/generated/commands/zcount.test.ts
@@ -17,18 +17,8 @@ test("docs/redis-doc/commands/zcount.md example 1", async () => {
     outputs.r0 = await client.zadd("myzset", [1, "one"]);
     outputs.r1 = await client.zadd("myzset", [2, "two"]);
     outputs.r2 = await client.zadd("myzset", [3, "three"]);
-    // Error decoding command `ZCOUNT myzset -inf +inf`:
-
-    // decoding ZCOUNT overload 0 (key,min,max): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [-inf,+inf], target args remainin count: 2
-    // -inf parsed into a bad number NaN
-    // ---
-    // Error decoding command `ZCOUNT myzset (1 3`:
-
-    // decoding ZCOUNT overload 0 (key,min,max): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,3], target args remainin count: 2
-    // (1 parsed into a bad number NaN
-    // ---
+    outputs.r3 = await client.zcount("myzset", "-inf", "+inf");
+    outputs.r4 = await client.zcount("myzset", "(1", 3);
 
     expect(fuzzify(outputs, __filename)).toMatchInlineSnapshot(`
         Object {

--- a/test/generated/commands/zrangebyscore.test.ts
+++ b/test/generated/commands/zrangebyscore.test.ts
@@ -17,61 +17,10 @@ test("docs/redis-doc/commands/zrangebyscore.md example 1", async () => {
     outputs.r0 = await client.zadd("myzset", [1, "one"]);
     outputs.r1 = await client.zadd("myzset", [2, "two"]);
     outputs.r2 = await client.zadd("myzset", [3, "three"]);
-    // Error decoding command `ZRANGEBYSCORE myzset -inf +inf`:
-
-    // decoding ZRANGEBYSCORE overload 0 (key,min,max): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [-inf,+inf], target args remainin count: 2
-    // -inf parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 1 (key,min,max,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [-inf,+inf], target args remainin count: 3
-    // -inf parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 2 (key,min,max,withscores): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [-inf,+inf], target args remainin count: 3
-    // -inf parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 3 (key,min,max,withscores,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [-inf,+inf], target args remainin count: 4
-    // -inf parsed into a bad number NaN
-    // ---
+    outputs.r3 = await client.zrangebyscore("myzset", "-inf", "+inf");
     outputs.r4 = await client.zrangebyscore("myzset", 1, 2);
-    // Error decoding command `ZRANGEBYSCORE myzset (1 2`:
-
-    // decoding ZRANGEBYSCORE overload 0 (key,min,max): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,2], target args remainin count: 2
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 1 (key,min,max,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,2], target args remainin count: 3
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 2 (key,min,max,withscores): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,2], target args remainin count: 3
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 3 (key,min,max,withscores,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,2], target args remainin count: 4
-    // (1 parsed into a bad number NaN
-    // ---
-    // Error decoding command `ZRANGEBYSCORE myzset (1 (2`:
-
-    // decoding ZRANGEBYSCORE overload 0 (key,min,max): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,(2], target args remainin count: 2
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 1 (key,min,max,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,(2], target args remainin count: 3
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 2 (key,min,max,withscores): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,(2], target args remainin count: 3
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZRANGEBYSCORE overload 3 (key,min,max,withscores,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(1,(2], target args remainin count: 4
-    // (1 parsed into a bad number NaN
-    // ---
+    outputs.r5 = await client.zrangebyscore("myzset", "(1", 2);
+    outputs.r6 = await client.zrangebyscore("myzset", "(1", "(2");
 
     expect(fuzzify(outputs, __filename)).toMatchInlineSnapshot(`
         Object {

--- a/test/generated/commands/zrangebyscore.test.ts
+++ b/test/generated/commands/zrangebyscore.test.ts
@@ -27,10 +27,19 @@ test("docs/redis-doc/commands/zrangebyscore.md example 1", async () => {
           "r0": 1,
           "r1": 1,
           "r2": 1,
+          "r3": Array [
+            "one",
+            "two",
+            "three",
+          ],
           "r4": Array [
             "one",
             "two",
           ],
+          "r5": Array [
+            "two",
+          ],
+          "r6": Array [],
         }
     `);
 });

--- a/test/generated/commands/zremrangebyscore.test.ts
+++ b/test/generated/commands/zremrangebyscore.test.ts
@@ -17,12 +17,7 @@ test("docs/redis-doc/commands/zremrangebyscore.md example 1", async () => {
     outputs.r0 = await client.zadd("myzset", [1, "one"]);
     outputs.r1 = await client.zadd("myzset", [2, "two"]);
     outputs.r2 = await client.zadd("myzset", [3, "three"]);
-    // Error decoding command `ZREMRANGEBYSCORE myzset -inf (2`:
-
-    // decoding ZREMRANGEBYSCORE overload 0 (key,min,max): { name: 'key', schema: { type: 'string' } },{ name: 'min', schema: { type: 'number' } },{ name: 'max', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [-inf,(2], target args remainin count: 2
-    // -inf parsed into a bad number NaN
-    // ---
+    outputs.r3 = await client.zremrangebyscore("myzset", "-inf", "(2");
     outputs.r4 = await client.zrange("myzset", 0, -1, "WITHSCORES");
 
     expect(fuzzify(outputs, __filename)).toMatchInlineSnapshot(`

--- a/test/generated/commands/zremrangebyscore.test.ts
+++ b/test/generated/commands/zremrangebyscore.test.ts
@@ -25,9 +25,8 @@ test("docs/redis-doc/commands/zremrangebyscore.md example 1", async () => {
           "r0": 1,
           "r1": 1,
           "r2": 1,
+          "r3": 1,
           "r4": Array [
-            "one",
-            "1",
             "two",
             "2",
             "three",

--- a/test/generated/commands/zrevrangebyscore.test.ts
+++ b/test/generated/commands/zrevrangebyscore.test.ts
@@ -17,65 +17,10 @@ test("docs/redis-doc/commands/zrevrangebyscore.md example 1", async () => {
     outputs.r0 = await client.zadd("myzset", [1, "one"]);
     outputs.r1 = await client.zadd("myzset", [2, "two"]);
     outputs.r2 = await client.zadd("myzset", [3, "three"]);
-    // Error decoding command `ZREVRANGEBYSCORE myzset +inf -inf`:
-
-    // decoding ZREVRANGEBYSCORE overload 0 (key,max,min): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [+inf,-inf], target args remainin count: 2
-    // +inf parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 1 (key,max,min,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [+inf,-inf], target args remainin count: 3
-    // +inf parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 2 (key,max,min,withscores): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [+inf,-inf], target args remainin count: 3
-    // +inf parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 3 (key,max,min,withscores,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [+inf,-inf], target args remainin count: 4
-    // +inf parsed into a bad number NaN
-    // ---
+    outputs.r3 = await client.zrevrangebyscore("myzset", "+inf", "-inf");
     outputs.r4 = await client.zrevrangebyscore("myzset", 2, 1);
-    // Error decoding command `ZREVRANGEBYSCORE myzset 2 (1`:
-
-    // decoding ZREVRANGEBYSCORE overload 0 (key,max,min): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [2,(1], target args remainin count: 2
-    // 2 successfully decoded as max (string). Decoded value 2. Tokens remaining [(1], target args remainin count: 1
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 1 (key,max,min,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [2,(1], target args remainin count: 3
-    // 2 successfully decoded as max (string). Decoded value 2. Tokens remaining [(1], target args remainin count: 2
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 2 (key,max,min,withscores): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [2,(1], target args remainin count: 3
-    // 2 successfully decoded as max (string). Decoded value 2. Tokens remaining [(1], target args remainin count: 2
-    // (1 parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 3 (key,max,min,withscores,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [2,(1], target args remainin count: 4
-    // 2 successfully decoded as max (string). Decoded value 2. Tokens remaining [(1], target args remainin count: 3
-    // (1 parsed into a bad number NaN
-    // ---
-    // Error decoding command `ZREVRANGEBYSCORE myzset (2 (1`:
-
-    // decoding ZREVRANGEBYSCORE overload 0 (key,max,min): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(2,(1], target args remainin count: 2
-    // (2 parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 1 (key,max,min,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(2,(1], target args remainin count: 3
-    // (2 parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 2 (key,max,min,withscores): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(2,(1], target args remainin count: 3
-    // (2 parsed into a bad number NaN
-    // ---
-    // decoding ZREVRANGEBYSCORE overload 3 (key,max,min,withscores,LIMIT_offset_count): { name: 'key', schema: { type: 'string' } },{ name: 'max', schema: { type: 'number' } },{ name: 'min', schema: { type: 'number' } },{ name: 'withscores', optional: true, schema: { type: 'string', enum: [ 'WITHSCORES' ] } },{ name: 'LIMIT_offset_count', optional: true, schema: { type: 'array', items: [ { type: 'string', const: 'LIMIT' }, { type: 'array', items: [ { title: 'offset', type: 'integer' }, { title: 'count', type: 'integer' } ] } ] }, toString: [Function] }
-    // myzset successfully decoded as key (string). Decoded value myzset. Tokens remaining [(2,(1], target args remainin count: 4
-    // (2 parsed into a bad number NaN
-    // ---
+    outputs.r5 = await client.zrevrangebyscore("myzset", 2, "(1");
+    outputs.r6 = await client.zrevrangebyscore("myzset", "(2", "(1");
 
     expect(fuzzify(outputs, __filename)).toMatchInlineSnapshot(`
         Object {

--- a/test/generated/commands/zrevrangebyscore.test.ts
+++ b/test/generated/commands/zrevrangebyscore.test.ts
@@ -27,10 +27,19 @@ test("docs/redis-doc/commands/zrevrangebyscore.md example 1", async () => {
           "r0": 1,
           "r1": 1,
           "r2": 1,
+          "r3": Array [
+            "three",
+            "two",
+            "one",
+          ],
           "r4": Array [
             "two",
             "one",
           ],
+          "r5": Array [
+            "two",
+          ],
+          "r6": Array [],
         }
     `);
 });


### PR DESCRIPTION
Fixes #30 

Now that v2 has a more maintainable "patching" system, this works around https://github.com/redis/redis-doc/issues/1420 - to be removed if a fix is merged there.

This effectively allows string values to be passed as `min` and `max` for ZRANGEBYSCORE, ZREMRANGEBYSCORE, ZREVRANGEBYSCORE and ZCOUNT.

Note: in future, it may be possible to use [template literal types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#template-literal-types) to only allow strings like `(1` rather than _any_ strings, but it's likely too complex and will require a higher typescript version than most users have.