### PR TITLE
Fix type declarations for typescript <4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "_": "echo \"these pass-through-to-docker scripts are mostly just as a hint for when I come back to this in a few weeks and forget what I'm supposed to do.\"",
     "prebuild": "yarn codegen",
     "build": "yarn typecheck && yarn compile",
+    "postbuild": "sed -i 's~declare type Push_ts4~// @ts-ignore (https://github.com/mmkal/handy-redis/pulls/251)\\ndeclare type Push_ts4~g' dist/type-util.d.ts",
     "check-clean": "check-clean",
     "ci": "run-s clean build coverage lint check-clean",
     "preclean": "del-cli temp/backup-test-generated && mkdir -p temp && cp -r test/generated temp/backup-test-generated",

--- a/src/node_redis/multi.ts
+++ b/src/node_redis/multi.ts
@@ -2,16 +2,7 @@ import * as nodeRedis from "redis";
 import { flattenDeep } from "../flatten";
 import { Commands } from "../generated/interface";
 import { promisify } from "util";
-
-// Variadic tuple prefixes only work in ts>4. To support lower typescript versions, check if the feature works
-// this means we need ts-ignore, not ts-expect-error because it's _not_ an error in ts>4
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-type Push_ts4<A extends unknown[], B> = [...A, B];
-type VariadicTuplesPrefixesSupported = Push_ts4<[1, 2], 3> extends { length: 3 } ? "yes" : "no";
-type Push<A extends unknown[], B> = VariadicTuplesPrefixesSupported extends "yes"
-    ? Push_ts4<A, B>
-    : Array<A[number] | B>;
+import { Push } from "../type-util";
 
 export type ResultType<K extends keyof Commands> = ReturnType<Commands[K]> extends Promise<infer X> ? X : never;
 

--- a/src/type-util.ts
+++ b/src/type-util.ts
@@ -1,0 +1,14 @@
+// Variadic tuple prefixes only work in ts>4. To support lower typescript versions, check if the feature works
+// this means we need ts-ignore, not ts-expect-error because it's _not_ an error in ts>4
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+type Push_ts4<A extends unknown[], B> = [...A, B];
+type VariadicTuplesPrefixesSupported = Push_ts4<[1, 2], 3> extends [1, 2, 3] ? "yes" : "no";
+
+/**
+ * @example
+ * Push<[1, 2], 3> // resolves to [1, 2, 3] for typescript>=4, or (1 | 2 | 3)[] for typescript<4
+ */
+export type Push<A extends unknown[], B> = VariadicTuplesPrefixesSupported extends "yes"
+    ? Push_ts4<A, B>
+    : Array<A[number] | B>;

--- a/src/type-util.ts
+++ b/src/type-util.ts
@@ -1,5 +1,6 @@
-// Variadic tuple prefixes only work in ts>4. To support lower typescript versions, check if the feature works
-// this means we need ts-ignore, not ts-expect-error because it's _not_ an error in ts>4
+// Rest elements must be last in tuple types prior to typescript 4.x. To support lower typescript versions, check if the feature works
+// this means we need ts-ignore, not ts-expect-error because it's _not_ an error in ts>=4
+// Note: this ts-ignore doesn't get emitted to d.ts, so it needs to be re-added in "postbuild" (see package.json)
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 type Push_ts4<A extends unknown[], B> = [...A, B];


### PR DESCRIPTION
Fixes #250 

ts-ignore isn't included in d.ts files, so typescript versions that don't support rest elements. This works around by using `sed` to re-add the `// @ts-ignore` directive. Probably a better solution would be to use `typesVersions`, but as far as I can tell that would mean compiling two completely different versions of the types, which seems like overkill for this one small utility that _can_ just use a conditional.