### PR TITLE
Named tuple types

### DIFF
--- a/codegen/__tests__/generate-client.test.ts
+++ b/codegen/__tests__/generate-client.test.ts
@@ -32,7 +32,7 @@ test("formatOverloads", () => {
                          * 
                          * [Full docs](https://redis.io/commands/latency-reset)
                          */
-                        latency(latency_subcommand: \\"RESET\\", ...event?: Array<string>):
+                        latency(latency_subcommand: \\"RESET\\", ...event: Array<string>):
                             Promise<unknown>
                     ",
         ]
@@ -72,7 +72,7 @@ test("formatOverloads", () => {
                          * 
                          * [Full docs](https://redis.io/commands/set)
                          */
-                        set(key: string, value: string, expiration?: ([(\\"EX\\"|\\"PX\\"), (number)]) | (\\"KEEPTTL\\"), get?: \\"GET\\"):
+                        set(key: string, value: string, expiration?: ([ex_px: (\\"EX\\"|\\"PX\\"), number: (number)]) | (\\"KEEPTTL\\"), get?: \\"GET\\"):
                             Promise<(\\"OK\\") | (string) | (null)>
                     ",
           "
@@ -84,7 +84,7 @@ test("formatOverloads", () => {
                          * 
                          * [Full docs](https://redis.io/commands/set)
                          */
-                        set(key: string, value: string, expiration?: ([(\\"EX\\"|\\"PX\\"), (number)]) | (\\"KEEPTTL\\"), condition?: \\"NX\\"|\\"XX\\", get?: \\"GET\\"):
+                        set(key: string, value: string, expiration?: ([ex_px: (\\"EX\\"|\\"PX\\"), number: (number)]) | (\\"KEEPTTL\\"), condition?: \\"NX\\"|\\"XX\\", get?: \\"GET\\"):
                             Promise<(\\"OK\\") | (string) | (null)>
                     ",
         ]

--- a/codegen/__tests__/generate-tests.test.ts
+++ b/codegen/__tests__/generate-tests.test.ts
@@ -40,7 +40,7 @@ describe("toArgs", () => {
             Object {
               "command": "set",
               "context": Array [
-                "decoding set overload 0 (key,value): { name: 'key', schema: { type: 'string' } },{ name: 'value', schema: { type: 'string' } }",
+                "decoding set overload 0 (key,value): { name: 'key', schema: { title: 'key', type: 'string' } },{ name: 'value', schema: { title: 'value', type: 'string' } }",
                 "foo successfully decoded as key (string). Decoded value foo. Tokens remaining [bar,WRONG,123], target args remainin count: 1",
                 "bar successfully decoded as value (string). Decoded value bar. Tokens remaining [WRONG,123], target args remainin count: 0",
                 "Tokens remain but no target args left! Tokens: WRONG,123",
@@ -76,7 +76,7 @@ describe("toArgs", () => {
             Object {
               "command": "setbit",
               "context": Array [
-                "decoding setbit overload 0 (key,offset,value): { name: 'key', schema: { type: 'string' } },{ name: 'offset', schema: { type: 'integer' } },{ name: 'value', schema: { type: 'integer' } }",
+                "decoding setbit overload 0 (key,offset,value): { name: 'key', schema: { title: 'key', type: 'string' } },{ name: 'offset', schema: { title: 'offset', type: 'integer' } },{ name: 'value', schema: { title: 'value', type: 'integer' } }",
                 "foo successfully decoded as key (string). Decoded value foo. Tokens remaining [1.2,34], target args remainin count: 2",
                 "1.2 isn't an integer. Decoded as something different: 1",
               ],
@@ -89,7 +89,7 @@ describe("toArgs", () => {
             Object {
               "command": "setbit",
               "context": Array [
-                "decoding setbit overload 0 (key,offset,value): { name: 'key', schema: { type: 'string' } },{ name: 'offset', schema: { type: 'integer' } },{ name: 'value', schema: { type: 'integer' } }",
+                "decoding setbit overload 0 (key,offset,value): { name: 'key', schema: { title: 'key', type: 'string' } },{ name: 'offset', schema: { title: 'offset', type: 'integer' } },{ name: 'value', schema: { title: 'value', type: 'integer' } }",
                 "foo successfully decoded as key (string). Decoded value foo. Tokens remaining [not_an_integer,34], target args remainin count: 2",
                 "not_an_integer isn't an integer. Decoded as something different: NaN",
               ],

--- a/codegen/command.ts
+++ b/codegen/command.ts
@@ -43,16 +43,17 @@ export interface Command {
         | "sorted_set";
 }
 
-export type ArgumentType = "string" | "key" | "enum" | "pattern" | "integer" | "double" | "posix time";
+export type ArgumentType = "string" | "key" | "enum" | "pattern" | "integer" | "double" | "posix time" | "block";
 
 export interface Argument {
-    name: string;
+    name?: string;
     type: ArgumentType | ArgumentType[];
     command?: string;
     enum?: string[];
     optional?: boolean;
     multiple?: boolean;
     variadic?: boolean;
+    block?: Array<Argument>;
 }
 
 export interface CommandCollection {

--- a/codegen/generate-schema.ts
+++ b/codegen/generate-schema.ts
@@ -6,7 +6,16 @@ import * as commandTypes from "./command";
 import { fixupSchema } from "./patches/schema";
 import { JsonSchemaCommand } from ".";
 
-const argToSchema = (arg: commandTypes.Argument): jsonSchema.JSONSchema7 => {
+const argToSchema: typeof argToSchemaNoTitle = arg => {
+    const schema = argToSchemaNoTitle(arg);
+    const name = arg.name || arg.enum?.map?.((e, i, a) => (i > 0 && i === a.length - 1 ? `or ${e}` : e));
+    return {
+        title: arg.command || (Array.isArray(name) ? name.join(", ") : name),
+        ...schema,
+    };
+};
+
+const argToSchemaNoTitle = (arg: commandTypes.Argument): jsonSchema.JSONSchema7 => {
     if (arg.variadic && arg.command) {
         return {
             type: "array",
@@ -20,6 +29,12 @@ const argToSchema = (arg: commandTypes.Argument): jsonSchema.JSONSchema7 => {
         return {
             type: "array",
             items: argToSchema({ ...arg, multiple: false, variadic: false }),
+        };
+    }
+    if (arg.command && !arg.type) {
+        return {
+            type: "string",
+            const: arg.command,
         };
     }
     if (arg.command) {
@@ -78,8 +93,8 @@ const argToSchema = (arg: commandTypes.Argument): jsonSchema.JSONSchema7 => {
         return {
             type: "array",
             items: arg.type.map((type, i) => ({
-                title: arg.name[i],
-                ...argToSchema({ type, name: arg.name[i] }),
+                title: arg.name?.[i],
+                ...argToSchema({ type, name: arg.name?.[i] }),
             })),
         };
     }
@@ -139,20 +154,24 @@ const argToReturn = (command: string): jsonSchema.JSONSchema7 => {
 
 const jsonSchemaCommand = (command: commandTypes.Command, key: string): JsonSchemaCommand => ({
     ...command,
-    arguments: (command?.arguments || []).map(arg => ({
-        name: [arg.command, arg.name]
-            .flat()
-            .filter(
-                (val, i, arr) =>
-                    val &&
-                    val !== arr[i - 1] &&
-                    val.toUpperCase() !== arr[i - 1] &&
-                    val.toUpperCase() + "S" !== arr[i - 1]
-            )
-            .join("_"),
-        optional: arg.optional,
-        schema: argToSchema(arg),
-    })),
+    arguments: (command?.arguments || []).map(arg => {
+        const schema = argToSchema(arg);
+        return {
+            name: [arg.command, schema.title || arg.name]
+                .flat()
+                .filter((val, i, arr) => val && !arr[i + 1]?.toUpperCase().startsWith(val.toUpperCase()))
+                .filter(
+                    (val, i, arr) =>
+                        val &&
+                        val !== arr[i - 1] &&
+                        val.toUpperCase() !== arr[i - 1] &&
+                        val.toUpperCase() + "S" !== arr[i - 1]
+                )
+                .join("_"),
+            optional: arg.optional,
+            schema,
+        };
+    }),
     return: argToReturn(key),
 });
 

--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -38,6 +38,7 @@
             {
                 "name": "username",
                 "schema": {
+                    "title": "username",
                     "type": "string"
                 }
             }
@@ -53,6 +54,7 @@
             {
                 "name": "username",
                 "schema": {
+                    "title": "username",
                     "type": "string"
                 }
             },
@@ -60,8 +62,10 @@
                 "name": "rule",
                 "optional": true,
                 "schema": {
+                    "title": "rule",
                     "type": "array",
                     "items": {
+                        "title": "rule",
                         "type": "string"
                     }
                 }
@@ -78,8 +82,10 @@
             {
                 "name": "username",
                 "schema": {
+                    "title": "username",
                     "type": "array",
                     "items": {
+                        "title": "username",
                         "type": "string"
                     }
                 }
@@ -97,6 +103,7 @@
                 "name": "categoryname",
                 "optional": true,
                 "schema": {
+                    "title": "categoryname",
                     "type": "string"
                 }
             }
@@ -113,6 +120,7 @@
                 "name": "bits",
                 "optional": true,
                 "schema": {
+                    "title": "bits",
                     "type": "integer"
                 }
             }
@@ -137,6 +145,7 @@
                 "name": "count or RESET",
                 "optional": true,
                 "schema": {
+                    "title": "count or RESET",
                     "type": "string"
                 }
             }
@@ -160,12 +169,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -183,12 +194,14 @@
                 "name": "username",
                 "optional": true,
                 "schema": {
+                    "title": "username",
                     "type": "string"
                 }
             },
             {
                 "name": "password",
                 "schema": {
+                    "title": "password",
                     "type": "string"
                 }
             }
@@ -216,6 +229,7 @@
                 "name": "schedule",
                 "optional": true,
                 "schema": {
+                    "title": "schedule",
                     "type": "string",
                     "enum": ["SCHEDULE"]
                 }
@@ -235,13 +249,15 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "start_end",
+                "name": "start, end",
                 "optional": true,
                 "schema": {
+                    "title": "start, end",
                     "type": "array",
                     "items": [
                         {
@@ -269,13 +285,15 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "GET_type_offset",
+                "name": "GET",
                 "optional": true,
                 "schema": {
+                    "title": "GET",
                     "type": "array",
                     "items": [
                         {
@@ -283,6 +301,7 @@
                             "const": "GET"
                         },
                         {
+                            "title": "type, offset",
                             "type": "array",
                             "items": [
                                 {
@@ -299,9 +318,10 @@
                 }
             },
             {
-                "name": "SET_type_offset_value",
+                "name": "SET",
                 "optional": true,
                 "schema": {
+                    "title": "SET",
                     "type": "array",
                     "items": [
                         {
@@ -309,6 +329,7 @@
                             "const": "SET"
                         },
                         {
+                            "title": "type, offset, value",
                             "type": "array",
                             "items": [
                                 {
@@ -329,9 +350,10 @@
                 }
             },
             {
-                "name": "INCRBY_type_offset_increment",
+                "name": "INCRBY",
                 "optional": true,
                 "schema": {
+                    "title": "INCRBY",
                     "type": "array",
                     "items": [
                         {
@@ -339,6 +361,7 @@
                             "const": "INCRBY"
                         },
                         {
+                            "title": "type, offset, increment",
                             "type": "array",
                             "items": [
                                 {
@@ -362,6 +385,7 @@
                 "name": "OVERFLOW",
                 "optional": true,
                 "schema": {
+                    "title": "OVERFLOW",
                     "type": "array",
                     "items": [
                         {
@@ -369,6 +393,7 @@
                             "const": "OVERFLOW"
                         },
                         {
+                            "title": "WRAP, SAT, or FAIL",
                             "type": "string",
                             "enum": ["WRAP", "SAT", "FAIL"]
                         }
@@ -387,20 +412,24 @@
             {
                 "name": "operation",
                 "schema": {
+                    "title": "operation",
                     "type": "string"
                 }
             },
             {
                 "name": "destkey",
                 "schema": {
+                    "title": "destkey",
                     "type": "string"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -419,12 +448,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "bit",
                 "schema": {
+                    "title": "bit",
                     "type": "integer"
                 }
             },
@@ -432,6 +463,7 @@
                 "name": "start",
                 "optional": true,
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
@@ -439,6 +471,7 @@
                 "name": "end",
                 "optional": true,
                 "schema": {
+                    "title": "end",
                     "type": "integer"
                 }
             }
@@ -456,8 +489,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -465,6 +500,7 @@
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "number"
                 }
             }
@@ -489,8 +525,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -498,6 +536,7 @@
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "number"
                 }
             }
@@ -522,18 +561,21 @@
             {
                 "name": "source",
                 "schema": {
+                    "title": "source",
                     "type": "string"
                 }
             },
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "number"
                 }
             }
@@ -558,18 +600,21 @@
             {
                 "name": "source",
                 "schema": {
+                    "title": "source",
                     "type": "string"
                 }
             },
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "wherefrom",
                 "schema": {
+                    "title": "wherefrom",
                     "type": "string",
                     "enum": ["LEFT", "RIGHT"]
                 }
@@ -577,6 +622,7 @@
             {
                 "name": "whereto",
                 "schema": {
+                    "title": "whereto",
                     "type": "string",
                     "enum": ["LEFT", "RIGHT"]
                 }
@@ -584,6 +630,7 @@
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "number"
                 }
             }
@@ -608,8 +655,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -617,6 +666,7 @@
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "number"
                 }
             }
@@ -641,8 +691,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -650,6 +702,7 @@
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "number"
                 }
             }
@@ -674,6 +727,7 @@
             {
                 "name": "mode",
                 "schema": {
+                    "title": "mode",
                     "type": "string",
                     "enum": ["YES", "NO"]
                 }
@@ -699,13 +753,15 @@
                 "name": "ip:port",
                 "optional": true,
                 "schema": {
+                    "title": "ip:port",
                     "type": "string"
                 }
             },
             {
-                "name": "ID_client-id",
+                "name": "ID",
                 "optional": true,
                 "schema": {
+                    "title": "ID",
                     "type": "array",
                     "items": [
                         {
@@ -713,6 +769,7 @@
                             "const": "ID"
                         },
                         {
+                            "title": "client-id",
                             "type": "integer"
                         }
                     ]
@@ -722,6 +779,7 @@
                 "name": "TYPE",
                 "optional": true,
                 "schema": {
+                    "title": "TYPE",
                     "type": "array",
                     "items": [
                         {
@@ -729,6 +787,7 @@
                             "const": "TYPE"
                         },
                         {
+                            "title": "normal, master, slave, or pubsub",
                             "type": "string",
                             "enum": ["normal", "master", "slave", "pubsub"]
                         }
@@ -736,9 +795,10 @@
                 }
             },
             {
-                "name": "USER_username",
+                "name": "USER",
                 "optional": true,
                 "schema": {
+                    "title": "USER",
                     "type": "array",
                     "items": [
                         {
@@ -746,15 +806,17 @@
                             "const": "USER"
                         },
                         {
+                            "title": "username",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "ADDR_ip:port",
+                "name": "ADDR",
                 "optional": true,
                 "schema": {
+                    "title": "ADDR",
                     "type": "array",
                     "items": [
                         {
@@ -762,15 +824,17 @@
                             "const": "ADDR"
                         },
                         {
+                            "title": "ip:port",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "SKIPME_yes/no",
+                "name": "SKIPME",
                 "optional": true,
                 "schema": {
+                    "title": "SKIPME",
                     "type": "array",
                     "items": [
                         {
@@ -778,6 +842,7 @@
                             "const": "SKIPME"
                         },
                         {
+                            "title": "yes/no",
                             "type": "string"
                         }
                     ]
@@ -796,6 +861,7 @@
                 "name": "TYPE",
                 "optional": true,
                 "schema": {
+                    "title": "TYPE",
                     "type": "array",
                     "items": [
                         {
@@ -803,6 +869,7 @@
                             "const": "TYPE"
                         },
                         {
+                            "title": "normal, master, replica, or pubsub",
                             "type": "string",
                             "enum": ["normal", "master", "replica", "pubsub"]
                         }
@@ -837,6 +904,7 @@
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "integer"
                 }
             }
@@ -852,6 +920,7 @@
             {
                 "name": "reply-mode",
                 "schema": {
+                    "title": "reply-mode",
                     "type": "string",
                     "enum": ["ON", "OFF", "SKIP"]
                 }
@@ -869,6 +938,7 @@
             {
                 "name": "connection-name",
                 "schema": {
+                    "title": "connection-name",
                     "type": "string"
                 }
             }
@@ -883,14 +953,16 @@
             {
                 "name": "status",
                 "schema": {
+                    "title": "status",
                     "type": "string",
                     "enum": ["ON", "OFF"]
                 }
             },
             {
-                "name": "REDIRECT_client-id",
+                "name": "REDIRECT",
                 "optional": true,
                 "schema": {
+                    "title": "REDIRECT",
                     "type": "array",
                     "items": [
                         {
@@ -898,6 +970,7 @@
                             "const": "REDIRECT"
                         },
                         {
+                            "title": "client-id",
                             "type": "integer"
                         }
                     ]
@@ -907,8 +980,10 @@
                 "name": "PREFIX",
                 "optional": true,
                 "schema": {
+                    "title": "PREFIX",
                     "type": "array",
                     "items": {
+                        "title": "PREFIX",
                         "type": "array",
                         "items": [
                             {
@@ -916,6 +991,7 @@
                                 "const": "PREFIX"
                             },
                             {
+                                "title": "prefix",
                                 "type": "string"
                             }
                         ]
@@ -926,6 +1002,7 @@
                 "name": "BCAST",
                 "optional": true,
                 "schema": {
+                    "title": "BCAST",
                     "type": "string",
                     "enum": ["BCAST"]
                 }
@@ -934,6 +1011,7 @@
                 "name": "OPTIN",
                 "optional": true,
                 "schema": {
+                    "title": "OPTIN",
                     "type": "string",
                     "enum": ["OPTIN"]
                 }
@@ -942,6 +1020,7 @@
                 "name": "OPTOUT",
                 "optional": true,
                 "schema": {
+                    "title": "OPTOUT",
                     "type": "string",
                     "enum": ["OPTOUT"]
                 }
@@ -950,6 +1029,7 @@
                 "name": "NOLOOP",
                 "optional": true,
                 "schema": {
+                    "title": "NOLOOP",
                     "type": "string",
                     "enum": ["NOLOOP"]
                 }
@@ -966,6 +1046,7 @@
             {
                 "name": "client-id",
                 "schema": {
+                    "title": "client-id",
                     "type": "integer"
                 }
             },
@@ -973,6 +1054,7 @@
                 "name": "unblock-type",
                 "optional": true,
                 "schema": {
+                    "title": "unblock-type",
                     "type": "string",
                     "enum": ["TIMEOUT", "ERROR"]
                 }
@@ -989,8 +1071,10 @@
             {
                 "name": "slot",
                 "schema": {
+                    "title": "slot",
                     "type": "array",
                     "items": {
+                        "title": "slot",
                         "type": "integer"
                     }
                 }
@@ -1015,6 +1099,7 @@
             {
                 "name": "node-id",
                 "schema": {
+                    "title": "node-id",
                     "type": "string"
                 }
             }
@@ -1030,6 +1115,7 @@
             {
                 "name": "slot",
                 "schema": {
+                    "title": "slot",
                     "type": "integer"
                 }
             }
@@ -1045,8 +1131,10 @@
             {
                 "name": "slot",
                 "schema": {
+                    "title": "slot",
                     "type": "array",
                     "items": {
+                        "title": "slot",
                         "type": "integer"
                     }
                 }
@@ -1064,6 +1152,7 @@
                 "name": "options",
                 "optional": true,
                 "schema": {
+                    "title": "options",
                     "type": "string",
                     "enum": ["FORCE", "TAKEOVER"]
                 }
@@ -1088,6 +1177,7 @@
             {
                 "name": "node-id",
                 "schema": {
+                    "title": "node-id",
                     "type": "string"
                 }
             }
@@ -1103,12 +1193,14 @@
             {
                 "name": "slot",
                 "schema": {
+                    "title": "slot",
                     "type": "integer"
                 }
             },
             {
                 "name": "count",
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             }
@@ -1132,6 +1224,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -1147,12 +1240,14 @@
             {
                 "name": "ip",
                 "schema": {
+                    "title": "ip",
                     "type": "string"
                 }
             },
             {
                 "name": "port",
                 "schema": {
+                    "title": "port",
                     "type": "integer"
                 }
             }
@@ -1184,6 +1279,7 @@
             {
                 "name": "node-id",
                 "schema": {
+                    "title": "node-id",
                     "type": "string"
                 }
             }
@@ -1200,6 +1296,7 @@
                 "name": "reset-type",
                 "optional": true,
                 "schema": {
+                    "title": "reset-type",
                     "type": "string",
                     "enum": ["HARD", "SOFT"]
                 }
@@ -1224,6 +1321,7 @@
             {
                 "name": "config-epoch",
                 "schema": {
+                    "title": "config-epoch",
                     "type": "integer"
                 }
             }
@@ -1239,12 +1337,14 @@
             {
                 "name": "slot",
                 "schema": {
+                    "title": "slot",
                     "type": "integer"
                 }
             },
             {
                 "name": "subcommand",
                 "schema": {
+                    "title": "subcommand",
                     "type": "string",
                     "enum": ["IMPORTING", "MIGRATING", "STABLE", "NODE"]
                 }
@@ -1253,6 +1353,7 @@
                 "name": "node-id",
                 "optional": true,
                 "schema": {
+                    "title": "node-id",
                     "type": "string"
                 }
             }
@@ -1268,6 +1369,7 @@
             {
                 "name": "node-id",
                 "schema": {
+                    "title": "node-id",
                     "type": "string"
                 }
             }
@@ -1283,6 +1385,7 @@
             {
                 "name": "node-id",
                 "schema": {
+                    "title": "node-id",
                     "type": "string"
                 }
             }
@@ -1333,8 +1436,10 @@
             {
                 "name": "command-name",
                 "schema": {
+                    "title": "command-name",
                     "type": "array",
                     "items": {
+                        "title": "command-name",
                         "type": "string"
                     }
                 }
@@ -1349,6 +1454,7 @@
             {
                 "name": "parameter",
                 "schema": {
+                    "title": "parameter",
                     "type": "string"
                 }
             }
@@ -1370,12 +1476,14 @@
             {
                 "name": "parameter",
                 "schema": {
+                    "title": "parameter",
                     "type": "string"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -1407,6 +1515,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -1429,6 +1538,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -1446,12 +1556,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "decrement",
                 "schema": {
+                    "title": "decrement",
                     "type": "integer"
                 }
             }
@@ -1469,8 +1581,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -1499,6 +1613,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -1515,6 +1630,7 @@
             {
                 "name": "message",
                 "schema": {
+                    "title": "message",
                     "type": "string"
                 }
             }
@@ -1532,20 +1648,24 @@
             {
                 "name": "script",
                 "schema": {
+                    "title": "script",
                     "type": "string"
                 }
             },
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -1553,8 +1673,10 @@
             {
                 "name": "arg",
                 "schema": {
+                    "title": "arg",
                     "type": "array",
                     "items": {
+                        "title": "arg",
                         "type": "string"
                     }
                 }
@@ -1571,20 +1693,24 @@
             {
                 "name": "sha1",
                 "schema": {
+                    "title": "sha1",
                     "type": "string"
                 }
             },
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -1592,8 +1718,10 @@
             {
                 "name": "arg",
                 "schema": {
+                    "title": "arg",
                     "type": "array",
                     "items": {
+                        "title": "arg",
                         "type": "string"
                     }
                 }
@@ -1626,8 +1754,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -1646,12 +1776,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "seconds",
                 "schema": {
+                    "title": "seconds",
                     "type": "integer"
                 }
             }
@@ -1669,12 +1801,15 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "timestamp",
-                "schema": {}
+                "schema": {
+                    "title": "timestamp"
+                }
             }
         ],
         "since": "1.2.0",
@@ -1690,6 +1825,7 @@
                 "name": "async",
                 "optional": true,
                 "schema": {
+                    "title": "async",
                     "type": "string",
                     "enum": ["ASYNC"]
                 }
@@ -1709,6 +1845,7 @@
                 "name": "async",
                 "optional": true,
                 "schema": {
+                    "title": "async",
                     "type": "string",
                     "enum": ["ASYNC"]
                 }
@@ -1728,14 +1865,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "longitude_latitude_member",
+                "name": "longitude, latitude, member",
                 "schema": {
+                    "title": "longitude, latitude, member",
                     "type": "array",
                     "items": {
+                        "title": "longitude, latitude, member",
                         "type": "array",
                         "items": [
                             {
@@ -1768,14 +1908,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -1797,14 +1940,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -1830,18 +1976,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member1",
                 "schema": {
+                    "title": "member1",
                     "type": "string"
                 }
             },
             {
                 "name": "member2",
                 "schema": {
+                    "title": "member2",
                     "type": "string"
                 }
             },
@@ -1849,6 +1998,7 @@
                 "name": "unit",
                 "optional": true,
                 "schema": {
+                    "title": "unit",
                     "type": "string",
                     "enum": ["m", "km", "ft", "mi"]
                 }
@@ -1874,30 +2024,35 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "longitude",
                 "schema": {
+                    "title": "longitude",
                     "type": "number"
                 }
             },
             {
                 "name": "latitude",
                 "schema": {
+                    "title": "latitude",
                     "type": "number"
                 }
             },
             {
                 "name": "radius",
                 "schema": {
+                    "title": "radius",
                     "type": "number"
                 }
             },
             {
                 "name": "unit",
                 "schema": {
+                    "title": "unit",
                     "type": "string",
                     "enum": ["m", "km", "ft", "mi"]
                 }
@@ -1906,6 +2061,7 @@
                 "name": "withcoord",
                 "optional": true,
                 "schema": {
+                    "title": "withcoord",
                     "type": "string",
                     "enum": ["WITHCOORD"]
                 }
@@ -1914,6 +2070,7 @@
                 "name": "withdist",
                 "optional": true,
                 "schema": {
+                    "title": "withdist",
                     "type": "string",
                     "enum": ["WITHDIST"]
                 }
@@ -1922,6 +2079,7 @@
                 "name": "withhash",
                 "optional": true,
                 "schema": {
+                    "title": "withhash",
                     "type": "string",
                     "enum": ["WITHHASH"]
                 }
@@ -1930,6 +2088,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -1937,6 +2096,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -1946,14 +2106,16 @@
                 "name": "order",
                 "optional": true,
                 "schema": {
+                    "title": "order",
                     "type": "string",
                     "enum": ["ASC", "DESC"]
                 }
             },
             {
-                "name": "STORE_key",
+                "name": "STORE",
                 "optional": true,
                 "schema": {
+                    "title": "STORE",
                     "type": "array",
                     "items": [
                         {
@@ -1961,15 +2123,17 @@
                             "const": "STORE"
                         },
                         {
+                            "title": "key",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "STOREDIST_key",
+                "name": "STOREDIST",
                 "optional": true,
                 "schema": {
+                    "title": "STOREDIST",
                     "type": "array",
                     "items": [
                         {
@@ -1977,6 +2141,7 @@
                             "const": "STOREDIST"
                         },
                         {
+                            "title": "key",
                             "type": "string"
                         }
                     ]
@@ -1996,24 +2161,28 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             },
             {
                 "name": "radius",
                 "schema": {
+                    "title": "radius",
                     "type": "number"
                 }
             },
             {
                 "name": "unit",
                 "schema": {
+                    "title": "unit",
                     "type": "string",
                     "enum": ["m", "km", "ft", "mi"]
                 }
@@ -2022,6 +2191,7 @@
                 "name": "withcoord",
                 "optional": true,
                 "schema": {
+                    "title": "withcoord",
                     "type": "string",
                     "enum": ["WITHCOORD"]
                 }
@@ -2030,6 +2200,7 @@
                 "name": "withdist",
                 "optional": true,
                 "schema": {
+                    "title": "withdist",
                     "type": "string",
                     "enum": ["WITHDIST"]
                 }
@@ -2038,6 +2209,7 @@
                 "name": "withhash",
                 "optional": true,
                 "schema": {
+                    "title": "withhash",
                     "type": "string",
                     "enum": ["WITHHASH"]
                 }
@@ -2046,6 +2218,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -2053,6 +2226,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -2062,14 +2236,16 @@
                 "name": "order",
                 "optional": true,
                 "schema": {
+                    "title": "order",
                     "type": "string",
                     "enum": ["ASC", "DESC"]
                 }
             },
             {
-                "name": "STORE_key",
+                "name": "STORE",
                 "optional": true,
                 "schema": {
+                    "title": "STORE",
                     "type": "array",
                     "items": [
                         {
@@ -2077,15 +2253,17 @@
                             "const": "STORE"
                         },
                         {
+                            "title": "key",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "STOREDIST_key",
+                "name": "STOREDIST",
                 "optional": true,
                 "schema": {
+                    "title": "STOREDIST",
                     "type": "array",
                     "items": [
                         {
@@ -2093,6 +2271,7 @@
                             "const": "STOREDIST"
                         },
                         {
+                            "title": "key",
                             "type": "string"
                         }
                     ]
@@ -2110,6 +2289,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2134,12 +2314,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "offset",
                 "schema": {
+                    "title": "offset",
                     "type": "integer"
                 }
             }
@@ -2157,18 +2339,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
             {
                 "name": "end",
                 "schema": {
+                    "title": "end",
                     "type": "integer"
                 }
             }
@@ -2186,12 +2371,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -2216,14 +2403,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "array",
                     "items": {
+                        "title": "field",
                         "type": "string"
                     }
                 }
@@ -2242,13 +2432,15 @@
             {
                 "name": "protover",
                 "schema": {
+                    "title": "protover",
                     "type": "integer"
                 }
             },
             {
-                "name": "AUTH_username_password",
+                "name": "AUTH",
                 "optional": true,
                 "schema": {
+                    "title": "AUTH",
                     "type": "array",
                     "items": [
                         {
@@ -2256,6 +2448,7 @@
                             "const": "AUTH"
                         },
                         {
+                            "title": "username, password",
                             "type": "array",
                             "items": [
                                 {
@@ -2272,9 +2465,10 @@
                 }
             },
             {
-                "name": "SETNAME_clientname",
+                "name": "SETNAME",
                 "optional": true,
                 "schema": {
+                    "title": "SETNAME",
                     "type": "array",
                     "items": [
                         {
@@ -2282,6 +2476,7 @@
                             "const": "SETNAME"
                         },
                         {
+                            "title": "clientname",
                             "type": "string"
                         }
                     ]
@@ -2301,12 +2496,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "string"
                 }
             }
@@ -2324,12 +2521,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "string"
                 }
             }
@@ -2354,6 +2553,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2371,18 +2571,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "string"
                 }
             },
             {
                 "name": "increment",
                 "schema": {
+                    "title": "increment",
                     "type": "integer"
                 }
             }
@@ -2400,18 +2603,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "string"
                 }
             },
             {
                 "name": "increment",
                 "schema": {
+                    "title": "increment",
                     "type": "number"
                 }
             }
@@ -2429,6 +2635,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2449,6 +2656,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2466,14 +2674,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "array",
                     "items": {
+                        "title": "field",
                         "type": "string"
                     }
                 }
@@ -2502,14 +2713,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "field_value",
+                "name": "field, value",
                 "schema": {
+                    "title": "field, value",
                     "type": "array",
                     "items": {
+                        "title": "field, value",
                         "type": "array",
                         "items": [
                             {
@@ -2539,14 +2753,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "field_value",
+                "name": "field, value",
                 "schema": {
+                    "title": "field, value",
                     "type": "array",
                     "items": {
+                        "title": "field, value",
                         "type": "array",
                         "items": [
                             {
@@ -2575,18 +2792,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "string"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -2604,12 +2824,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "field",
                 "schema": {
+                    "title": "field",
                     "type": "string"
                 }
             }
@@ -2627,6 +2849,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2647,6 +2870,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2664,12 +2888,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "increment",
                 "schema": {
+                    "title": "increment",
                     "type": "integer"
                 }
             }
@@ -2687,12 +2913,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "increment",
                 "schema": {
+                    "title": "increment",
                     "type": "number"
                 }
             }
@@ -2710,6 +2938,7 @@
                 "name": "section",
                 "optional": true,
                 "schema": {
+                    "title": "section",
                     "type": "string"
                 }
             }
@@ -2727,6 +2956,7 @@
                 "name": "VERSION",
                 "optional": true,
                 "schema": {
+                    "title": "VERSION",
                     "type": "array",
                     "items": [
                         {
@@ -2734,6 +2964,7 @@
                             "const": "VERSION"
                         },
                         {
+                            "title": "version",
                             "type": "integer"
                         }
                     ]
@@ -2753,6 +2984,7 @@
             {
                 "name": "pattern",
                 "schema": {
+                    "title": "pattern",
                     "type": "string"
                 }
             }
@@ -2782,12 +3014,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "index",
                 "schema": {
+                    "title": "index",
                     "type": "integer"
                 }
             }
@@ -2812,12 +3046,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "where",
                 "schema": {
+                    "title": "where",
                     "type": "string",
                     "enum": ["BEFORE", "AFTER"]
                 }
@@ -2825,12 +3061,14 @@
             {
                 "name": "pivot",
                 "schema": {
+                    "title": "pivot",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "string"
                 }
             }
@@ -2848,6 +3086,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2865,6 +3104,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -2889,12 +3129,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "string"
                 }
             },
@@ -2902,6 +3144,7 @@
                 "name": "RANK",
                 "optional": true,
                 "schema": {
+                    "title": "RANK",
                     "type": "array",
                     "items": [
                         {
@@ -2909,15 +3152,17 @@
                             "const": "RANK"
                         },
                         {
+                            "title": "rank",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "COUNT_num-matches",
+                "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -2925,15 +3170,17 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "num-matches",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "MAXLEN_len",
+                "name": "MAXLEN",
                 "optional": true,
                 "schema": {
+                    "title": "MAXLEN",
                     "type": "array",
                     "items": [
                         {
@@ -2941,6 +3188,7 @@
                             "const": "MAXLEN"
                         },
                         {
+                            "title": "len",
                             "type": "integer"
                         }
                     ]
@@ -2958,14 +3206,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "array",
                     "items": {
+                        "title": "element",
                         "type": "string"
                     }
                 }
@@ -2984,14 +3235,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "array",
                     "items": {
+                        "title": "element",
                         "type": "string"
                     }
                 }
@@ -3010,18 +3264,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
             {
                 "name": "stop",
                 "schema": {
+                    "title": "stop",
                     "type": "integer"
                 }
             }
@@ -3042,18 +3299,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "count",
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "string"
                 }
             }
@@ -3071,18 +3331,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "index",
                 "schema": {
+                    "title": "index",
                     "type": "integer"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "string"
                 }
             }
@@ -3101,18 +3364,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
             {
                 "name": "stop",
                 "schema": {
+                    "title": "stop",
                     "type": "integer"
                 }
             }
@@ -3166,13 +3432,15 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "SAMPLES_count",
+                "name": "SAMPLES",
                 "optional": true,
                 "schema": {
+                    "title": "SAMPLES",
                     "type": "array",
                     "items": [
                         {
@@ -3180,6 +3448,7 @@
                             "const": "SAMPLES"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -3197,8 +3466,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -3227,18 +3498,21 @@
             {
                 "name": "host",
                 "schema": {
+                    "title": "host",
                     "type": "string"
                 }
             },
             {
                 "name": "port",
                 "schema": {
+                    "title": "port",
                     "type": "string"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string",
                     "enum": ["key", "\"\""]
                 }
@@ -3246,12 +3520,14 @@
             {
                 "name": "destination-db",
                 "schema": {
+                    "title": "destination-db",
                     "type": "integer"
                 }
             },
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "integer"
                 }
             },
@@ -3259,6 +3535,7 @@
                 "name": "copy",
                 "optional": true,
                 "schema": {
+                    "title": "copy",
                     "type": "string",
                     "enum": ["COPY"]
                 }
@@ -3267,14 +3544,16 @@
                 "name": "replace",
                 "optional": true,
                 "schema": {
+                    "title": "replace",
                     "type": "string",
                     "enum": ["REPLACE"]
                 }
             },
             {
-                "name": "AUTH_password",
+                "name": "AUTH",
                 "optional": true,
                 "schema": {
+                    "title": "AUTH",
                     "type": "array",
                     "items": [
                         {
@@ -3282,15 +3561,17 @@
                             "const": "AUTH"
                         },
                         {
+                            "title": "password",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "AUTH2_username password",
+                "name": "AUTH2",
                 "optional": true,
                 "schema": {
+                    "title": "AUTH2",
                     "type": "array",
                     "items": [
                         {
@@ -3298,6 +3579,7 @@
                             "const": "AUTH2"
                         },
                         {
+                            "title": "username password",
                             "type": "string"
                         }
                     ]
@@ -3307,6 +3589,7 @@
                 "name": "KEYS",
                 "optional": true,
                 "schema": {
+                    "title": "KEYS",
                     "type": "array",
                     "items": [
                         {
@@ -3316,6 +3599,7 @@
                         {
                             "type": "array",
                             "items": {
+                                "title": "key",
                                 "type": "string"
                             }
                         }
@@ -3345,6 +3629,7 @@
             {
                 "name": "path",
                 "schema": {
+                    "title": "path",
                     "type": "string"
                 }
             },
@@ -3352,8 +3637,10 @@
                 "name": "arg",
                 "optional": true,
                 "schema": {
+                    "title": "arg",
                     "type": "array",
                     "items": {
+                        "title": "arg",
                         "type": "string"
                     }
                 }
@@ -3370,6 +3657,7 @@
             {
                 "name": "name",
                 "schema": {
+                    "title": "name",
                     "type": "string"
                 }
             }
@@ -3392,12 +3680,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "db",
                 "schema": {
+                    "title": "db",
                     "type": "integer"
                 }
             }
@@ -3413,10 +3703,12 @@
         "complexity": "O(N) where N is the number of keys to set.",
         "arguments": [
             {
-                "name": "key_value",
+                "name": "key, value",
                 "schema": {
+                    "title": "key, value",
                     "type": "array",
                     "items": {
+                        "title": "key, value",
                         "type": "array",
                         "items": [
                             {
@@ -3444,10 +3736,12 @@
         "complexity": "O(N) where N is the number of keys to set.",
         "arguments": [
             {
-                "name": "key_value",
+                "name": "key, value",
                 "schema": {
+                    "title": "key, value",
                     "type": "array",
                     "items": {
+                        "title": "key, value",
                         "type": "array",
                         "items": [
                             {
@@ -3488,6 +3782,7 @@
             {
                 "name": "subcommand",
                 "schema": {
+                    "title": "subcommand",
                     "type": "string"
                 }
             },
@@ -3495,8 +3790,10 @@
                 "name": "arguments",
                 "optional": true,
                 "schema": {
+                    "title": "arguments",
                     "type": "array",
                     "items": {
+                        "title": "arguments",
                         "type": "string"
                     }
                 }
@@ -3511,6 +3808,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -3528,12 +3826,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "milliseconds",
                 "schema": {
+                    "title": "milliseconds",
                     "type": "integer"
                 }
             }
@@ -3551,12 +3851,15 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "milliseconds-timestamp",
-                "schema": {}
+                "schema": {
+                    "title": "milliseconds-timestamp"
+                }
             }
         ],
         "since": "2.6.0",
@@ -3572,14 +3875,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "array",
                     "items": {
+                        "title": "element",
                         "type": "string"
                     }
                 }
@@ -3598,8 +3904,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -3618,14 +3926,17 @@
             {
                 "name": "destkey",
                 "schema": {
+                    "title": "destkey",
                     "type": "string"
                 }
             },
             {
                 "name": "sourcekey",
                 "schema": {
+                    "title": "sourcekey",
                     "type": "array",
                     "items": {
+                        "title": "sourcekey",
                         "type": "string"
                     }
                 }
@@ -3645,6 +3956,7 @@
                 "name": "message",
                 "optional": true,
                 "schema": {
+                    "title": "message",
                     "type": "string"
                 }
             }
@@ -3663,18 +3975,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "milliseconds",
                 "schema": {
+                    "title": "milliseconds",
                     "type": "integer"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -3690,8 +4005,10 @@
             {
                 "name": "pattern",
                 "schema": {
+                    "title": "pattern",
                     "type": "array",
                     "items": {
+                        "title": "pattern",
                         "type": "array",
                         "items": [
                             {
@@ -3714,6 +4031,7 @@
             {
                 "name": "subcommand",
                 "schema": {
+                    "title": "subcommand",
                     "type": "string"
                 }
             },
@@ -3721,8 +4039,10 @@
                 "name": "argument",
                 "optional": true,
                 "schema": {
+                    "title": "argument",
                     "type": "array",
                     "items": {
+                        "title": "argument",
                         "type": "string"
                     }
                 }
@@ -3741,6 +4061,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -3758,12 +4079,14 @@
             {
                 "name": "channel",
                 "schema": {
+                    "title": "channel",
                     "type": "string"
                 }
             },
             {
                 "name": "message",
                 "schema": {
+                    "title": "message",
                     "type": "string"
                 }
             }
@@ -3782,8 +4105,10 @@
                 "name": "pattern",
                 "optional": true,
                 "schema": {
+                    "title": "pattern",
                     "type": "array",
                     "items": {
+                        "title": "pattern",
                         "type": "string"
                     }
                 }
@@ -3849,12 +4174,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "newkey",
                 "schema": {
+                    "title": "newkey",
                     "type": "string"
                 }
             }
@@ -3873,12 +4200,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "newkey",
                 "schema": {
+                    "title": "newkey",
                     "type": "string"
                 }
             }
@@ -3906,18 +4235,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "ttl",
                 "schema": {
+                    "title": "ttl",
                     "type": "integer"
                 }
             },
             {
                 "name": "serialized-value",
                 "schema": {
+                    "title": "serialized-value",
                     "type": "string"
                 }
             },
@@ -3925,6 +4257,7 @@
                 "name": "replace",
                 "optional": true,
                 "schema": {
+                    "title": "replace",
                     "type": "string",
                     "enum": ["REPLACE"]
                 }
@@ -3933,14 +4266,16 @@
                 "name": "absttl",
                 "optional": true,
                 "schema": {
+                    "title": "absttl",
                     "type": "string",
                     "enum": ["ABSTTL"]
                 }
             },
             {
-                "name": "IDLETIME_seconds",
+                "name": "IDLETIME",
                 "optional": true,
                 "schema": {
+                    "title": "IDLETIME",
                     "type": "array",
                     "items": [
                         {
@@ -3948,15 +4283,17 @@
                             "const": "IDLETIME"
                         },
                         {
+                            "title": "seconds",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "FREQ_frequency",
+                "name": "FREQ",
                 "optional": true,
                 "schema": {
+                    "title": "FREQ",
                     "type": "array",
                     "items": [
                         {
@@ -3964,6 +4301,7 @@
                             "const": "FREQ"
                         },
                         {
+                            "title": "frequency",
                             "type": "integer"
                         }
                     ]
@@ -3993,6 +4331,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -4017,12 +4356,14 @@
             {
                 "name": "source",
                 "schema": {
+                    "title": "source",
                     "type": "string"
                 }
             },
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             }
@@ -4040,18 +4381,21 @@
             {
                 "name": "source",
                 "schema": {
+                    "title": "source",
                     "type": "string"
                 }
             },
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "wherefrom",
                 "schema": {
+                    "title": "wherefrom",
                     "type": "string",
                     "enum": ["LEFT", "RIGHT"]
                 }
@@ -4059,6 +4403,7 @@
             {
                 "name": "whereto",
                 "schema": {
+                    "title": "whereto",
                     "type": "string",
                     "enum": ["LEFT", "RIGHT"]
                 }
@@ -4077,14 +4422,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "array",
                     "items": {
+                        "title": "element",
                         "type": "string"
                     }
                 }
@@ -4103,14 +4451,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "element",
                 "schema": {
+                    "title": "element",
                     "type": "array",
                     "items": {
+                        "title": "element",
                         "type": "string"
                     }
                 }
@@ -4129,14 +4480,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -4165,6 +4519,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -4182,6 +4537,7 @@
             {
                 "name": "mode",
                 "schema": {
+                    "title": "mode",
                     "type": "string",
                     "enum": ["YES", "SYNC", "NO"]
                 }
@@ -4198,8 +4554,10 @@
             {
                 "name": "sha1",
                 "schema": {
+                    "title": "sha1",
                     "type": "array",
                     "items": {
+                        "title": "sha1",
                         "type": "string"
                     }
                 }
@@ -4232,6 +4590,7 @@
             {
                 "name": "script",
                 "schema": {
+                    "title": "script",
                     "type": "string"
                 }
             }
@@ -4247,8 +4606,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -4270,14 +4631,17 @@
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -4295,6 +4659,7 @@
             {
                 "name": "index",
                 "schema": {
+                    "title": "index",
                     "type": "integer"
                 }
             }
@@ -4313,12 +4678,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             },
@@ -4350,6 +4717,7 @@
                 "name": "condition",
                 "optional": true,
                 "schema": {
+                    "title": "condition",
                     "type": "string",
                     "enum": ["NX", "XX"]
                 }
@@ -4358,6 +4726,7 @@
                 "name": "get",
                 "optional": true,
                 "schema": {
+                    "title": "get",
                     "type": "string",
                     "enum": ["GET"]
                 }
@@ -4387,18 +4756,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "offset",
                 "schema": {
+                    "title": "offset",
                     "type": "integer"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "integer"
                 }
             }
@@ -4416,18 +4788,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "seconds",
                 "schema": {
+                    "title": "seconds",
                     "type": "integer"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -4446,12 +4821,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -4469,18 +4846,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "offset",
                 "schema": {
+                    "title": "offset",
                     "type": "integer"
                 }
             },
             {
                 "name": "value",
                 "schema": {
+                    "title": "value",
                     "type": "string"
                 }
             }
@@ -4498,6 +4878,7 @@
                 "name": "save-mode",
                 "optional": true,
                 "schema": {
+                    "title": "save-mode",
                     "type": "string",
                     "enum": ["NOSAVE", "SAVE"]
                 }
@@ -4517,8 +4898,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -4540,14 +4923,17 @@
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -4566,12 +4952,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             }
@@ -4589,14 +4977,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -4614,12 +5005,14 @@
             {
                 "name": "host",
                 "schema": {
+                    "title": "host",
                     "type": "string"
                 }
             },
             {
                 "name": "port",
                 "schema": {
+                    "title": "port",
                     "type": "string"
                 }
             }
@@ -4637,12 +5030,14 @@
             {
                 "name": "host",
                 "schema": {
+                    "title": "host",
                     "type": "string"
                 }
             },
             {
                 "name": "port",
                 "schema": {
+                    "title": "port",
                     "type": "string"
                 }
             }
@@ -4660,6 +5055,7 @@
             {
                 "name": "subcommand",
                 "schema": {
+                    "title": "subcommand",
                     "type": "string"
                 }
             },
@@ -4667,6 +5063,7 @@
                 "name": "argument",
                 "optional": true,
                 "schema": {
+                    "title": "argument",
                     "type": "string"
                 }
             }
@@ -4682,6 +5079,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -4702,18 +5100,21 @@
             {
                 "name": "source",
                 "schema": {
+                    "title": "source",
                     "type": "string"
                 }
             },
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             }
@@ -4731,13 +5132,15 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
-                "name": "BY_pattern",
+                "name": "BY",
                 "optional": true,
                 "schema": {
+                    "title": "BY",
                     "type": "array",
                     "items": [
                         {
@@ -4745,15 +5148,17 @@
                             "const": "BY"
                         },
                         {
+                            "title": "pattern",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "LIMIT_offset_count",
+                "name": "LIMIT",
                 "optional": true,
                 "schema": {
+                    "title": "LIMIT",
                     "type": "array",
                     "items": [
                         {
@@ -4761,6 +5166,7 @@
                             "const": "LIMIT"
                         },
                         {
+                            "title": "offset, count",
                             "type": "array",
                             "items": [
                                 {
@@ -4777,11 +5183,13 @@
                 }
             },
             {
-                "name": "GET_pattern",
+                "name": "GET",
                 "optional": true,
                 "schema": {
+                    "title": "GET",
                     "type": "array",
                     "items": {
+                        "title": "GET",
                         "type": "array",
                         "items": [
                             {
@@ -4789,6 +5197,7 @@
                                 "const": "GET"
                             },
                             {
+                                "title": "pattern",
                                 "type": "string"
                             }
                         ]
@@ -4799,6 +5208,7 @@
                 "name": "order",
                 "optional": true,
                 "schema": {
+                    "title": "order",
                     "type": "string",
                     "enum": ["ASC", "DESC"]
                 }
@@ -4807,14 +5217,16 @@
                 "name": "sorting",
                 "optional": true,
                 "schema": {
+                    "title": "sorting",
                     "type": "string",
                     "enum": ["ALPHA"]
                 }
             },
             {
-                "name": "STORE_destination",
+                "name": "STORE",
                 "optional": true,
                 "schema": {
+                    "title": "STORE",
                     "type": "array",
                     "items": [
                         {
@@ -4822,6 +5234,7 @@
                             "const": "STORE"
                         },
                         {
+                            "title": "destination",
                             "type": "string"
                         }
                     ]
@@ -4848,6 +5261,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -4855,6 +5269,7 @@
                 "name": "count",
                 "optional": true,
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             }
@@ -4885,6 +5300,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -4892,6 +5308,7 @@
                 "name": "count",
                 "optional": true,
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             }
@@ -4919,14 +5336,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -4945,6 +5365,7 @@
             {
                 "name": "algorithm",
                 "schema": {
+                    "title": "algorithm",
                     "type": "string",
                     "enum": ["LCS"]
                 }
@@ -4952,8 +5373,10 @@
             {
                 "name": "algo-specific-argument",
                 "schema": {
+                    "title": "algo-specific-argument",
                     "type": "array",
                     "items": {
+                        "title": "algo-specific-argument",
                         "type": "string"
                     }
                 }
@@ -4970,6 +5393,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -4987,8 +5411,10 @@
             {
                 "name": "channel",
                 "schema": {
+                    "title": "channel",
                     "type": "array",
                     "items": {
+                        "title": "channel",
                         "type": "string"
                     }
                 }
@@ -5005,8 +5431,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5028,14 +5456,17 @@
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5053,12 +5484,14 @@
             {
                 "name": "index1",
                 "schema": {
+                    "title": "index1",
                     "type": "integer"
                 }
             },
             {
                 "name": "index2",
                 "schema": {
+                    "title": "index2",
                     "type": "integer"
                 }
             }
@@ -5083,12 +5516,14 @@
             {
                 "name": "replicationid",
                 "schema": {
+                    "title": "replicationid",
                     "type": "integer"
                 }
             },
             {
                 "name": "offset",
                 "schema": {
+                    "title": "offset",
                     "type": "integer"
                 }
             }
@@ -5117,8 +5552,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5137,6 +5574,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -5154,6 +5592,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -5173,8 +5612,10 @@
                 "name": "channel",
                 "optional": true,
                 "schema": {
+                    "title": "channel",
                     "type": "array",
                     "items": {
+                        "title": "channel",
                         "type": "string"
                     }
                 }
@@ -5191,8 +5632,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5222,12 +5665,14 @@
             {
                 "name": "numreplicas",
                 "schema": {
+                    "title": "numreplicas",
                     "type": "integer"
                 }
             },
             {
                 "name": "timeout",
                 "schema": {
+                    "title": "timeout",
                     "type": "integer"
                 }
             }
@@ -5245,8 +5690,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5266,6 +5713,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -5273,6 +5721,7 @@
                 "name": "condition",
                 "optional": true,
                 "schema": {
+                    "title": "condition",
                     "type": "string",
                     "enum": ["NX", "XX"]
                 }
@@ -5281,6 +5730,7 @@
                 "name": "comparison",
                 "optional": true,
                 "schema": {
+                    "title": "comparison",
                     "type": "string",
                     "enum": ["GT", "LT"]
                 }
@@ -5289,6 +5739,7 @@
                 "name": "change",
                 "optional": true,
                 "schema": {
+                    "title": "change",
                     "type": "string",
                     "enum": ["CH"]
                 }
@@ -5297,15 +5748,18 @@
                 "name": "increment",
                 "optional": true,
                 "schema": {
+                    "title": "increment",
                     "type": "string",
                     "enum": ["INCR"]
                 }
             },
             {
-                "name": "score_member",
+                "name": "score, member",
                 "schema": {
+                    "title": "score, member",
                     "type": "array",
                     "items": {
+                        "title": "score, member",
                         "type": "array",
                         "items": [
                             {
@@ -5344,6 +5798,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -5361,6 +5816,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -5414,14 +5870,17 @@
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5430,6 +5889,7 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
@@ -5448,20 +5908,24 @@
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5480,18 +5944,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "increment",
                 "schema": {
+                    "title": "increment",
                     "type": "integer"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             }
@@ -5509,14 +5976,17 @@
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5525,6 +5995,7 @@
                 "name": "WEIGHTS",
                 "optional": true,
                 "schema": {
+                    "title": "WEIGHTS",
                     "type": "array",
                     "items": [
                         {
@@ -5534,6 +6005,7 @@
                         {
                             "type": "array",
                             "items": {
+                                "title": "weight",
                                 "type": "integer"
                             }
                         }
@@ -5544,6 +6016,7 @@
                 "name": "AGGREGATE",
                 "optional": true,
                 "schema": {
+                    "title": "AGGREGATE",
                     "type": "array",
                     "items": [
                         {
@@ -5551,6 +6024,7 @@
                             "const": "AGGREGATE"
                         },
                         {
+                            "title": "aggregate",
                             "type": "string",
                             "enum": ["SUM", "MIN", "MAX"]
                         }
@@ -5561,6 +6035,7 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
@@ -5579,20 +6054,24 @@
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -5601,6 +6080,7 @@
                 "name": "WEIGHTS",
                 "optional": true,
                 "schema": {
+                    "title": "WEIGHTS",
                     "type": "array",
                     "items": [
                         {
@@ -5610,6 +6090,7 @@
                         {
                             "type": "array",
                             "items": {
+                                "title": "weight",
                                 "type": "integer"
                             }
                         }
@@ -5620,6 +6101,7 @@
                 "name": "AGGREGATE",
                 "optional": true,
                 "schema": {
+                    "title": "AGGREGATE",
                     "type": "array",
                     "items": [
                         {
@@ -5627,6 +6109,7 @@
                             "const": "AGGREGATE"
                         },
                         {
+                            "title": "aggregate",
                             "type": "string",
                             "enum": ["SUM", "MIN", "MAX"]
                         }
@@ -5647,18 +6130,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "min",
                 "schema": {
+                    "title": "min",
                     "type": "string"
                 }
             },
             {
                 "name": "max",
                 "schema": {
+                    "title": "max",
                     "type": "string"
                 }
             }
@@ -5676,6 +6162,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -5683,6 +6170,7 @@
                 "name": "count",
                 "optional": true,
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             }
@@ -5703,6 +6191,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -5710,6 +6199,7 @@
                 "name": "count",
                 "optional": true,
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             }
@@ -5730,18 +6220,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
             {
                 "name": "stop",
                 "schema": {
+                    "title": "stop",
                     "type": "integer"
                 }
             },
@@ -5749,6 +6242,7 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
@@ -5770,25 +6264,29 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "min",
                 "schema": {
+                    "title": "min",
                     "type": "string"
                 }
             },
             {
                 "name": "max",
                 "schema": {
+                    "title": "max",
                     "type": "string"
                 }
             },
             {
-                "name": "LIMIT_offset_count",
+                "name": "LIMIT",
                 "optional": true,
                 "schema": {
+                    "title": "LIMIT",
                     "type": "array",
                     "items": [
                         {
@@ -5796,6 +6294,7 @@
                             "const": "LIMIT"
                         },
                         {
+                            "title": "offset, count",
                             "type": "array",
                             "items": [
                                 {
@@ -5828,25 +6327,29 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "max",
                 "schema": {
+                    "title": "max",
                     "type": "string"
                 }
             },
             {
                 "name": "min",
                 "schema": {
+                    "title": "min",
                     "type": "string"
                 }
             },
             {
-                "name": "LIMIT_offset_count",
+                "name": "LIMIT",
                 "optional": true,
                 "schema": {
+                    "title": "LIMIT",
                     "type": "array",
                     "items": [
                         {
@@ -5854,6 +6357,7 @@
                             "const": "LIMIT"
                         },
                         {
+                            "title": "offset, count",
                             "type": "array",
                             "items": [
                                 {
@@ -5886,6 +6390,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -5929,14 +6434,16 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
             },
             {
-                "name": "LIMIT_offset_count",
+                "name": "LIMIT",
                 "optional": true,
                 "schema": {
+                    "title": "LIMIT",
                     "type": "array",
                     "items": [
                         {
@@ -5944,6 +6451,7 @@
                             "const": "LIMIT"
                         },
                         {
+                            "title": "offset, count",
                             "type": "array",
                             "items": [
                                 {
@@ -5976,12 +6484,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             }
@@ -6006,14 +6516,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -6032,18 +6545,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "min",
                 "schema": {
+                    "title": "min",
                     "type": "string"
                 }
             },
             {
                 "name": "max",
                 "schema": {
+                    "title": "max",
                     "type": "string"
                 }
             }
@@ -6061,18 +6577,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
             {
                 "name": "stop",
                 "schema": {
+                    "title": "stop",
                     "type": "integer"
                 }
             }
@@ -6090,6 +6609,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -6143,18 +6663,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "integer"
                 }
             },
             {
                 "name": "stop",
                 "schema": {
+                    "title": "stop",
                     "type": "integer"
                 }
             },
@@ -6162,6 +6685,7 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
@@ -6183,6 +6707,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
@@ -6226,14 +6751,16 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
             },
             {
-                "name": "LIMIT_offset_count",
+                "name": "LIMIT",
                 "optional": true,
                 "schema": {
+                    "title": "LIMIT",
                     "type": "array",
                     "items": [
                         {
@@ -6241,6 +6768,7 @@
                             "const": "LIMIT"
                         },
                         {
+                            "title": "offset, count",
                             "type": "array",
                             "items": [
                                 {
@@ -6270,12 +6798,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             }
@@ -6300,12 +6830,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "string"
                 }
             }
@@ -6323,14 +6855,17 @@
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -6339,6 +6874,7 @@
                 "name": "WEIGHTS",
                 "optional": true,
                 "schema": {
+                    "title": "WEIGHTS",
                     "type": "array",
                     "items": [
                         {
@@ -6348,6 +6884,7 @@
                         {
                             "type": "array",
                             "items": {
+                                "title": "weight",
                                 "type": "integer"
                             }
                         }
@@ -6358,6 +6895,7 @@
                 "name": "AGGREGATE",
                 "optional": true,
                 "schema": {
+                    "title": "AGGREGATE",
                     "type": "array",
                     "items": [
                         {
@@ -6365,6 +6903,7 @@
                             "const": "AGGREGATE"
                         },
                         {
+                            "title": "aggregate",
                             "type": "string",
                             "enum": ["SUM", "MIN", "MAX"]
                         }
@@ -6375,6 +6914,7 @@
                 "name": "withscores",
                 "optional": true,
                 "schema": {
+                    "title": "withscores",
                     "type": "string",
                     "enum": ["WITHSCORES"]
                 }
@@ -6393,14 +6933,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "member",
                 "schema": {
+                    "title": "member",
                     "type": "array",
                     "items": {
+                        "title": "member",
                         "type": "string"
                     }
                 }
@@ -6426,20 +6969,24 @@
             {
                 "name": "destination",
                 "schema": {
+                    "title": "destination",
                     "type": "string"
                 }
             },
             {
                 "name": "numkeys",
                 "schema": {
+                    "title": "numkeys",
                     "type": "integer"
                 }
             },
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -6448,6 +6995,7 @@
                 "name": "WEIGHTS",
                 "optional": true,
                 "schema": {
+                    "title": "WEIGHTS",
                     "type": "array",
                     "items": [
                         {
@@ -6457,6 +7005,7 @@
                         {
                             "type": "array",
                             "items": {
+                                "title": "weight",
                                 "type": "integer"
                             }
                         }
@@ -6467,6 +7016,7 @@
                 "name": "AGGREGATE",
                 "optional": true,
                 "schema": {
+                    "title": "AGGREGATE",
                     "type": "array",
                     "items": [
                         {
@@ -6474,6 +7024,7 @@
                             "const": "AGGREGATE"
                         },
                         {
+                            "title": "aggregate",
                             "type": "string",
                             "enum": ["SUM", "MIN", "MAX"]
                         }
@@ -6494,13 +7045,15 @@
             {
                 "name": "cursor",
                 "schema": {
+                    "title": "cursor",
                     "type": "integer"
                 }
             },
             {
-                "name": "MATCH_pattern",
+                "name": "MATCH",
                 "optional": true,
                 "schema": {
+                    "title": "MATCH",
                     "type": "array",
                     "items": [
                         {
@@ -6508,6 +7061,7 @@
                             "const": "MATCH"
                         },
                         {
+                            "title": "pattern",
                             "type": "string"
                         }
                     ]
@@ -6517,6 +7071,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -6524,6 +7079,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -6533,6 +7089,7 @@
                 "name": "TYPE",
                 "optional": true,
                 "schema": {
+                    "title": "TYPE",
                     "type": "array",
                     "items": [
                         {
@@ -6540,6 +7097,7 @@
                             "const": "TYPE"
                         },
                         {
+                            "title": "type",
                             "type": "string"
                         }
                     ]
@@ -6557,19 +7115,22 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "cursor",
                 "schema": {
+                    "title": "cursor",
                     "type": "integer"
                 }
             },
             {
-                "name": "MATCH_pattern",
+                "name": "MATCH",
                 "optional": true,
                 "schema": {
+                    "title": "MATCH",
                     "type": "array",
                     "items": [
                         {
@@ -6577,6 +7138,7 @@
                             "const": "MATCH"
                         },
                         {
+                            "title": "pattern",
                             "type": "string"
                         }
                     ]
@@ -6586,6 +7148,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -6593,6 +7156,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -6610,19 +7174,22 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "cursor",
                 "schema": {
+                    "title": "cursor",
                     "type": "integer"
                 }
             },
             {
-                "name": "MATCH_pattern",
+                "name": "MATCH",
                 "optional": true,
                 "schema": {
+                    "title": "MATCH",
                     "type": "array",
                     "items": [
                         {
@@ -6630,6 +7197,7 @@
                             "const": "MATCH"
                         },
                         {
+                            "title": "pattern",
                             "type": "string"
                         }
                     ]
@@ -6639,6 +7207,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -6646,6 +7215,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -6663,19 +7233,22 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "cursor",
                 "schema": {
+                    "title": "cursor",
                     "type": "integer"
                 }
             },
             {
-                "name": "MATCH_pattern",
+                "name": "MATCH",
                 "optional": true,
                 "schema": {
+                    "title": "MATCH",
                     "type": "array",
                     "items": [
                         {
@@ -6683,6 +7256,7 @@
                             "const": "MATCH"
                         },
                         {
+                            "title": "pattern",
                             "type": "string"
                         }
                     ]
@@ -6692,6 +7266,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -6699,6 +7274,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -6714,9 +7290,10 @@
         "complexity": "O(N) with N being the number of returned items for the subcommands CONSUMERS and GROUPS. The STREAM subcommand is O(log N) with N being the number of items in the stream.",
         "arguments": [
             {
-                "name": "CONSUMERS_key_groupname",
+                "name": "CONSUMERS",
                 "optional": true,
                 "schema": {
+                    "title": "CONSUMERS",
                     "type": "array",
                     "items": [
                         {
@@ -6724,6 +7301,7 @@
                             "const": "CONSUMERS"
                         },
                         {
+                            "title": "key, groupname",
                             "type": "array",
                             "items": [
                                 {
@@ -6740,9 +7318,10 @@
                 }
             },
             {
-                "name": "GROUPS_key",
+                "name": "GROUPS",
                 "optional": true,
                 "schema": {
+                    "title": "GROUPS",
                     "type": "array",
                     "items": [
                         {
@@ -6750,15 +7329,17 @@
                             "const": "GROUPS"
                         },
                         {
+                            "title": "key",
                             "type": "string"
                         }
                     ]
                 }
             },
             {
-                "name": "STREAM_key",
+                "name": "STREAM",
                 "optional": true,
                 "schema": {
+                    "title": "STREAM",
                     "type": "array",
                     "items": [
                         {
@@ -6766,6 +7347,7 @@
                             "const": "STREAM"
                         },
                         {
+                            "title": "key",
                             "type": "string"
                         }
                     ]
@@ -6775,6 +7357,7 @@
                 "name": "help",
                 "optional": true,
                 "schema": {
+                    "title": "help",
                     "type": "string",
                     "enum": ["HELP"]
                 }
@@ -6791,20 +7374,24 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "ID",
                 "schema": {
+                    "title": "ID",
                     "type": "string"
                 }
             },
             {
-                "name": "field_value",
+                "name": "field, value",
                 "schema": {
+                    "title": "field, value",
                     "type": "array",
                     "items": {
+                        "title": "field, value",
                         "type": "array",
                         "items": [
                             {
@@ -6833,12 +7420,14 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "strategy",
                 "schema": {
+                    "title": "strategy",
                     "type": "string",
                     "enum": ["MAXLEN"]
                 }
@@ -6847,6 +7436,7 @@
                 "name": "approx",
                 "optional": true,
                 "schema": {
+                    "title": "approx",
                     "type": "string",
                     "enum": ["~"]
                 }
@@ -6854,6 +7444,7 @@
             {
                 "name": "count",
                 "schema": {
+                    "title": "count",
                     "type": "integer"
                 }
             }
@@ -6871,14 +7462,17 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "ID",
                 "schema": {
+                    "title": "ID",
                     "type": "array",
                     "items": {
+                        "title": "ID",
                         "type": "string"
                     }
                 }
@@ -6897,18 +7491,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "string"
                 }
             },
             {
                 "name": "end",
                 "schema": {
+                    "title": "end",
                     "type": "string"
                 }
             },
@@ -6916,6 +7513,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -6923,6 +7521,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -6942,18 +7541,21 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "end",
                 "schema": {
+                    "title": "end",
                     "type": "string"
                 }
             },
             {
                 "name": "start",
                 "schema": {
+                    "title": "start",
                     "type": "string"
                 }
             },
@@ -6961,6 +7563,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -6968,6 +7571,7 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -6987,6 +7591,7 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             }
@@ -7005,6 +7610,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -7012,15 +7618,17 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "BLOCK_milliseconds",
+                "name": "BLOCK",
                 "optional": true,
                 "schema": {
+                    "title": "BLOCK",
                     "type": "array",
                     "items": [
                         {
@@ -7028,6 +7636,7 @@
                             "const": "BLOCK"
                         },
                         {
+                            "title": "milliseconds",
                             "type": "integer"
                         }
                     ]
@@ -7036,6 +7645,7 @@
             {
                 "name": "streams",
                 "schema": {
+                    "title": "streams",
                     "type": "string",
                     "enum": ["STREAMS"]
                 }
@@ -7043,8 +7653,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -7052,8 +7664,10 @@
             {
                 "name": "id",
                 "schema": {
+                    "title": "id",
                     "type": "array",
                     "items": {
+                        "title": "id",
                         "type": "string"
                     }
                 }
@@ -7070,9 +7684,10 @@
         "complexity": "O(1) for all the subcommands, with the exception of the DESTROY subcommand which takes an additional O(M) time in order to delete the M entries inside the consumer group pending entries list (PEL).",
         "arguments": [
             {
-                "name": "CREATE_key_groupname_id-or-$",
+                "name": "CREATE",
                 "optional": true,
                 "schema": {
+                    "title": "CREATE",
                     "type": "array",
                     "items": [
                         {
@@ -7080,6 +7695,7 @@
                             "const": "CREATE"
                         },
                         {
+                            "title": "key, groupname, id-or-$",
                             "type": "array",
                             "items": [
                                 {
@@ -7100,9 +7716,10 @@
                 }
             },
             {
-                "name": "SETID_key_groupname_id-or-$",
+                "name": "SETID",
                 "optional": true,
                 "schema": {
+                    "title": "SETID",
                     "type": "array",
                     "items": [
                         {
@@ -7110,6 +7727,7 @@
                             "const": "SETID"
                         },
                         {
+                            "title": "key, groupname, id-or-$",
                             "type": "array",
                             "items": [
                                 {
@@ -7130,9 +7748,10 @@
                 }
             },
             {
-                "name": "DESTROY_key_groupname",
+                "name": "DESTROY",
                 "optional": true,
                 "schema": {
+                    "title": "DESTROY",
                     "type": "array",
                     "items": [
                         {
@@ -7140,6 +7759,7 @@
                             "const": "DESTROY"
                         },
                         {
+                            "title": "key, groupname",
                             "type": "array",
                             "items": [
                                 {
@@ -7156,9 +7776,10 @@
                 }
             },
             {
-                "name": "CREATECONSUMER_key_groupname_consumername",
+                "name": "CREATECONSUMER",
                 "optional": true,
                 "schema": {
+                    "title": "CREATECONSUMER",
                     "type": "array",
                     "items": [
                         {
@@ -7166,6 +7787,7 @@
                             "const": "CREATECONSUMER"
                         },
                         {
+                            "title": "key, groupname, consumername",
                             "type": "array",
                             "items": [
                                 {
@@ -7186,9 +7808,10 @@
                 }
             },
             {
-                "name": "DELCONSUMER_key_groupname_consumername",
+                "name": "DELCONSUMER",
                 "optional": true,
                 "schema": {
+                    "title": "DELCONSUMER",
                     "type": "array",
                     "items": [
                         {
@@ -7196,6 +7819,7 @@
                             "const": "DELCONSUMER"
                         },
                         {
+                            "title": "key, groupname, consumername",
                             "type": "array",
                             "items": [
                                 {
@@ -7225,8 +7849,9 @@
         "complexity": "For each stream mentioned: O(M) with M being the number of elements returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay the O(N) time in order to serve the N clients blocked on the stream getting new data.",
         "arguments": [
             {
-                "name": "GROUP_consumer",
+                "name": "GROUP",
                 "schema": {
+                    "title": "GROUP",
                     "type": "array",
                     "items": [
                         {
@@ -7234,6 +7859,7 @@
                             "const": "GROUP"
                         },
                         {
+                            "title": "group, consumer",
                             "type": "array",
                             "items": [
                                 {
@@ -7253,6 +7879,7 @@
                 "name": "COUNT",
                 "optional": true,
                 "schema": {
+                    "title": "COUNT",
                     "type": "array",
                     "items": [
                         {
@@ -7260,15 +7887,17 @@
                             "const": "COUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "BLOCK_milliseconds",
+                "name": "BLOCK",
                 "optional": true,
                 "schema": {
+                    "title": "BLOCK",
                     "type": "array",
                     "items": [
                         {
@@ -7276,6 +7905,7 @@
                             "const": "BLOCK"
                         },
                         {
+                            "title": "milliseconds",
                             "type": "integer"
                         }
                     ]
@@ -7285,6 +7915,7 @@
                 "name": "noack",
                 "optional": true,
                 "schema": {
+                    "title": "noack",
                     "type": "string",
                     "enum": ["NOACK"]
                 }
@@ -7292,6 +7923,7 @@
             {
                 "name": "streams",
                 "schema": {
+                    "title": "streams",
                     "type": "string",
                     "enum": ["STREAMS"]
                 }
@@ -7299,8 +7931,10 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "array",
                     "items": {
+                        "title": "key",
                         "type": "string"
                     }
                 }
@@ -7308,8 +7942,10 @@
             {
                 "name": "ID",
                 "schema": {
+                    "title": "ID",
                     "type": "array",
                     "items": {
+                        "title": "ID",
                         "type": "string"
                     }
                 }
@@ -7326,20 +7962,24 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "group",
                 "schema": {
+                    "title": "group",
                     "type": "string"
                 }
             },
             {
                 "name": "ID",
                 "schema": {
+                    "title": "ID",
                     "type": "array",
                     "items": {
+                        "title": "ID",
                         "type": "string"
                     }
                 }
@@ -7358,40 +7998,47 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "group",
                 "schema": {
+                    "title": "group",
                     "type": "string"
                 }
             },
             {
                 "name": "consumer",
                 "schema": {
+                    "title": "consumer",
                     "type": "string"
                 }
             },
             {
                 "name": "min-idle-time",
                 "schema": {
+                    "title": "min-idle-time",
                     "type": "string"
                 }
             },
             {
                 "name": "ID",
                 "schema": {
+                    "title": "ID",
                     "type": "array",
                     "items": {
+                        "title": "ID",
                         "type": "string"
                     }
                 }
             },
             {
-                "name": "IDLE_ms",
+                "name": "IDLE",
                 "optional": true,
                 "schema": {
+                    "title": "IDLE",
                     "type": "array",
                     "items": [
                         {
@@ -7399,15 +8046,17 @@
                             "const": "IDLE"
                         },
                         {
+                            "title": "ms",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "TIME_ms-unix-time",
+                "name": "TIME",
                 "optional": true,
                 "schema": {
+                    "title": "TIME",
                     "type": "array",
                     "items": [
                         {
@@ -7415,15 +8064,17 @@
                             "const": "TIME"
                         },
                         {
+                            "title": "ms-unix-time",
                             "type": "integer"
                         }
                     ]
                 }
             },
             {
-                "name": "RETRYCOUNT_count",
+                "name": "RETRYCOUNT",
                 "optional": true,
                 "schema": {
+                    "title": "RETRYCOUNT",
                     "type": "array",
                     "items": [
                         {
@@ -7431,6 +8082,7 @@
                             "const": "RETRYCOUNT"
                         },
                         {
+                            "title": "count",
                             "type": "integer"
                         }
                     ]
@@ -7439,12 +8091,16 @@
             {
                 "name": "force",
                 "optional": true,
-                "schema": {}
+                "schema": {
+                    "title": "force"
+                }
             },
             {
                 "name": "justid",
                 "optional": true,
-                "schema": {}
+                "schema": {
+                    "title": "justid"
+                }
             }
         ],
         "since": "5.0.0",
@@ -7460,19 +8116,22 @@
             {
                 "name": "key",
                 "schema": {
+                    "title": "key",
                     "type": "string"
                 }
             },
             {
                 "name": "group",
                 "schema": {
+                    "title": "group",
                     "type": "string"
                 }
             },
             {
-                "name": "start_end_count",
+                "name": "start, end, count",
                 "optional": true,
                 "schema": {
+                    "title": "start, end, count",
                     "type": "array",
                     "items": [
                         {
@@ -7494,13 +8153,15 @@
                 "name": "consumer",
                 "optional": true,
                 "schema": {
+                    "title": "consumer",
                     "type": "string"
                 }
             },
             {
-                "name": "IDLE_min-idle-time",
+                "name": "IDLE",
                 "optional": true,
                 "schema": {
+                    "title": "IDLE",
                     "type": "array",
                     "items": [
                         {
@@ -7508,6 +8169,7 @@
                             "const": "IDLE"
                         },
                         {
+                            "title": "min-idle-time",
                             "type": "integer"
                         }
                     ]
@@ -7533,6 +8195,7 @@
             {
                 "name": "event",
                 "schema": {
+                    "title": "event",
                     "type": "string"
                 }
             }
@@ -7547,6 +8210,7 @@
             {
                 "name": "event",
                 "schema": {
+                    "title": "event",
                     "type": "string"
                 }
             }
@@ -7569,8 +8233,10 @@
                 "name": "event",
                 "optional": true,
                 "schema": {
+                    "title": "event",
                     "type": "array",
                     "items": {
+                        "title": "event",
                         "type": "string"
                     }
                 }

--- a/downlevel.js
+++ b/downlevel.js
@@ -1,0 +1,42 @@
+const childProcess = require("child_process");
+const fs = require("fs");
+
+const main = () => {
+    const tempFolder = `temp/downlevel`;
+    childProcess.execSync(`rm -rf ${tempFolder}`, { stdio: "inherit" });
+    fs.mkdirSync(`${tempFolder}`, { recursive: true });
+    childProcess.execSync(`cp -r dist ${tempFolder}/0`, { stdio: "inherit" });
+    for (let i = 1; i < 10; i++) {
+        const [prev, next] = [i - 1, i].map(n => `${tempFolder}/${n}`);
+        console.log(`downleveling into ${next}`);
+        childProcess.execSync(`downlevel-dts ${prev} ${next} --to=3.4`, { stdio: "inherit" });
+
+        const [prevResult, nextResult] = [prev, next].map(folder =>
+            fs.readFileSync(`${folder}/generated/interface.d.ts`).toString()
+        );
+        if (prevResult === nextResult) {
+            if (i <= 2) {
+                throw new Error(
+                    `downleveling stabilised too quickly, maybe https://github.com/sandersn/downlevel-dts/issues/50 has been fixed?`
+                );
+            }
+            const target = `ts34/dist`;
+            console.log(`downleveling stabilised after ${i} iterations, copying to ${target}.`);
+            childProcess.execSync(`rm -rf ${target}`, { stdio: "inherit" });
+            fs.mkdirSync("ts34", { recursive: true });
+            childProcess.execSync(`cp -r ${next} ${target}`, { stdio: "inherit" });
+            console.log(`Replacing push implementation incompatible with typescript < 4`);
+            childProcess.execSync(`mv ${target}/push.ts34.d.ts ${target}/push.d.ts`, { stdio: "inherit" });
+            console.log(`Running old version of typescript on output`);
+            childProcess.execSync(`npx -p typescript@3.8 tsc ts34/dist/index.d.ts --noEmit`, { stdio: "inherit" });
+            console.log(`Removing temporary files`);
+            childProcess.execSync(`rm -rf ${tempFolder}`, { stdio: "inherit" });
+            console.log("Done.");
+            return;
+        }
+        console.log({ prev, next }, "had different outputs, running again");
+    }
+    throw new Error(`Downleveling failed!`);
+};
+
+main();

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "clean": "del-cli 'dist' 'ts34' 'src/generated' 'test/generated'",
     "codegen": "ts-node codegen/generate-schema && ts-node codegen/generate-client && ts-node codegen/generate-tests",
     "compile": "tsc -p tsconfig.lib.json",
-    "postcompile": "downlevel-dts dist ts34/dist --to=3.4 && mv ts34/dist/push.ts34.d.ts ts34/dist/push.d.ts",
+    "postcompile": "node downlevel",
     "coverage": "yarn test --coverage",
     "coveralls": "yarn coverage --coverageReporters=text-lcov | coveralls",
     "lint": "eslint --max-warnings 0 --ext .ts,.js,.md .",

--- a/src/generated/interface.ts
+++ b/src/generated/interface.ts
@@ -177,17 +177,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/bitcount)
      */
-    bitcount(key: string, start_end?: [number, number]): Promise<number>;
-
-    /**
-     * Perform arbitrary bitfield integer operations on strings
-     * - _group_: string
-     * - _complexity_: O(1) for each subcommand specified
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/bitfield)
-     */
-    bitfield(key: string, overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]): Promise<unknown>;
+    bitcount(key: string, start_end?: [start: number, end: number]): Promise<number>;
 
     /**
      * Perform arbitrary bitfield integer operations on strings
@@ -199,8 +189,7 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        incrby_type_offset_increment?: ["INCRBY", [string, number, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -213,8 +202,8 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        set_type_offset_value?: ["SET", [string, number, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        incrby?: [incrby: "INCRBY", type_offset_increment: [type: string, offset: number, increment: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -227,9 +216,8 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        set_type_offset_value?: ["SET", [string, number, number]],
-        incrby_type_offset_increment?: ["INCRBY", [string, number, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        set?: [set: "SET", type_offset_value: [type: string, offset: number, value: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -242,8 +230,9 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        get_type_offset?: ["GET", [string, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        set?: [set: "SET", type_offset_value: [type: string, offset: number, value: number]],
+        incrby?: [incrby: "INCRBY", type_offset_increment: [type: string, offset: number, increment: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -256,9 +245,8 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        get_type_offset?: ["GET", [string, number]],
-        incrby_type_offset_increment?: ["INCRBY", [string, number, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        get?: [get: "GET", type_offset: [type: string, offset: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -271,9 +259,9 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        get_type_offset?: ["GET", [string, number]],
-        set_type_offset_value?: ["SET", [string, number, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        get?: [get: "GET", type_offset: [type: string, offset: number]],
+        incrby?: [incrby: "INCRBY", type_offset_increment: [type: string, offset: number, increment: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -286,10 +274,25 @@ export interface Commands {
      */
     bitfield(
         key: string,
-        get_type_offset?: ["GET", [string, number]],
-        set_type_offset_value?: ["SET", [string, number, number]],
-        incrby_type_offset_increment?: ["INCRBY", [string, number, number]],
-        overflow?: ["OVERFLOW", "WRAP" | "SAT" | "FAIL"]
+        get?: [get: "GET", type_offset: [type: string, offset: number]],
+        set?: [set: "SET", type_offset_value: [type: string, offset: number, value: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
+    ): Promise<unknown>;
+
+    /**
+     * Perform arbitrary bitfield integer operations on strings
+     * - _group_: string
+     * - _complexity_: O(1) for each subcommand specified
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/bitfield)
+     */
+    bitfield(
+        key: string,
+        get?: [get: "GET", type_offset: [type: string, offset: number]],
+        set?: [set: "SET", type_offset_value: [type: string, offset: number, value: number]],
+        incrby?: [incrby: "INCRBY", type_offset_increment: [type: string, offset: number, increment: number]],
+        overflow?: [overflow: "OVERFLOW", wrap_sat_or_fail: "WRAP" | "SAT" | "FAIL"]
     ): Promise<unknown>;
 
     /**
@@ -416,7 +419,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/client-kill)
      */
-    client(client_subcommand: "KILL", skipme_yes_no?: ["SKIPME", string]): Promise<unknown>;
+    client(client_subcommand: "KILL", skipme?: [skipme: "SKIPME", yes_no: string]): Promise<unknown>;
 
     /**
      * Kill the connection of a client
@@ -428,8 +431,8 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -442,8 +445,8 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -456,9 +459,9 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -471,8 +474,8 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -485,9 +488,9 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -500,9 +503,9 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -515,10 +518,10 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -531,8 +534,8 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -545,9 +548,9 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -560,9 +563,9 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -575,10 +578,10 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -591,9 +594,9 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -606,10 +609,10 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -622,10 +625,10 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -638,11 +641,11 @@ export interface Commands {
      */
     client(
         client_subcommand: "KILL",
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -653,7 +656,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/client-kill)
      */
-    client(client_subcommand: "KILL", ip_port?: string, skipme_yes_no?: ["SKIPME", string]): Promise<unknown>;
+    client(client_subcommand: "KILL", ip_port?: string, skipme?: [skipme: "SKIPME", yes_no: string]): Promise<unknown>;
 
     /**
      * Kill the connection of a client
@@ -666,23 +669,8 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
-    ): Promise<unknown>;
-
-    /**
-     * Kill the connection of a client
-     * - _group_: connection
-     * - _complexity_: O(N) where N is the number of client connections
-     * - _since_: 2.4.0
-     *
-     * [Full docs](https://redis.io/commands/client-kill)
-     */
-    client(
-        client_subcommand: "KILL",
-        ip_port?: string,
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -696,9 +684,8 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -712,8 +699,9 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        skipme_yes_no?: ["SKIPME", string]
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -727,9 +715,8 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -743,9 +730,9 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -759,10 +746,9 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -776,8 +762,10 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        skipme_yes_no?: ["SKIPME", string]
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -791,9 +779,8 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -807,9 +794,9 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -823,10 +810,9 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -840,9 +826,10 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -856,10 +843,9 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -873,10 +859,10 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -890,11 +876,28 @@ export interface Commands {
     client(
         client_subcommand: "KILL",
         ip_port?: string,
-        id_client_id?: ["ID", number],
-        type?: ["TYPE", "normal" | "master" | "slave" | "pubsub"],
-        user_username?: ["USER", string],
-        addr_ip_port?: ["ADDR", string],
-        skipme_yes_no?: ["SKIPME", string]
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
+    ): Promise<unknown>;
+
+    /**
+     * Kill the connection of a client
+     * - _group_: connection
+     * - _complexity_: O(N) where N is the number of client connections
+     * - _since_: 2.4.0
+     *
+     * [Full docs](https://redis.io/commands/client-kill)
+     */
+    client(
+        client_subcommand: "KILL",
+        ip_port?: string,
+        id?: [id: "ID", client_id: number],
+        type?: [type: "TYPE", normal_master_slave_or_pubsub: "normal" | "master" | "slave" | "pubsub"],
+        user?: [user: "USER", username: string],
+        addr?: [addr: "ADDR", ip_port: string],
+        skipme?: [skipme: "SKIPME", yes_no: string]
     ): Promise<unknown>;
 
     /**
@@ -905,7 +908,10 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/client-list)
      */
-    client(client_subcommand: "LIST", type?: ["TYPE", "normal" | "master" | "replica" | "pubsub"]): Promise<unknown>;
+    client(
+        client_subcommand: "LIST",
+        type?: [type: "TYPE", normal_master_replica_or_pubsub: "normal" | "master" | "replica" | "pubsub"]
+    ): Promise<unknown>;
 
     /**
      * Get the current connection name
@@ -1073,7 +1079,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         noloop?: "NOLOOP"
     ): Promise<unknown>;
 
@@ -1088,7 +1094,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         optout?: "OPTOUT",
         noloop?: "NOLOOP"
     ): Promise<unknown>;
@@ -1104,7 +1110,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         optin?: "OPTIN",
         noloop?: "NOLOOP"
     ): Promise<unknown>;
@@ -1120,75 +1126,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
-        optin?: "OPTIN",
-        optout?: "OPTOUT",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
-        bcast?: "BCAST",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
-        bcast?: "BCAST",
-        optout?: "OPTOUT",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
-        bcast?: "BCAST",
-        optin?: "OPTIN",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        prefix?: Array<["PREFIX", string]>,
-        bcast?: "BCAST",
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         optin?: "OPTIN",
         optout?: "OPTOUT",
         noloop?: "NOLOOP"
@@ -1205,71 +1143,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        optout?: "OPTOUT",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        optin?: "OPTIN",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        optin?: "OPTIN",
-        optout?: "OPTOUT",
-        noloop?: "NOLOOP"
-    ): Promise<unknown>;
-
-    /**
-     * Enable or disable server assisted client side caching support
-     * - _group_: connection
-     * - _complexity_: O(1)
-     * - _since_: 6.0.0
-     *
-     * [Full docs](https://redis.io/commands/client-tracking)
-     */
-    client(
-        client_subcommand: "TRACKING",
-        status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         bcast?: "BCAST",
         noloop?: "NOLOOP"
     ): Promise<unknown>;
@@ -1285,7 +1159,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         bcast?: "BCAST",
         optout?: "OPTOUT",
         noloop?: "NOLOOP"
@@ -1302,7 +1176,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         bcast?: "BCAST",
         optin?: "OPTIN",
         noloop?: "NOLOOP"
@@ -1319,7 +1193,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         bcast?: "BCAST",
         optin?: "OPTIN",
         optout?: "OPTOUT",
@@ -1337,8 +1211,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         noloop?: "NOLOOP"
     ): Promise<unknown>;
 
@@ -1353,8 +1226,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         optout?: "OPTOUT",
         noloop?: "NOLOOP"
     ): Promise<unknown>;
@@ -1370,8 +1242,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         optin?: "OPTIN",
         noloop?: "NOLOOP"
     ): Promise<unknown>;
@@ -1387,8 +1258,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         optin?: "OPTIN",
         optout?: "OPTOUT",
         noloop?: "NOLOOP"
@@ -1405,8 +1275,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         bcast?: "BCAST",
         noloop?: "NOLOOP"
     ): Promise<unknown>;
@@ -1422,8 +1291,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         bcast?: "BCAST",
         optout?: "OPTOUT",
         noloop?: "NOLOOP"
@@ -1440,8 +1308,7 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
         bcast?: "BCAST",
         optin?: "OPTIN",
         noloop?: "NOLOOP"
@@ -1458,8 +1325,147 @@ export interface Commands {
     client(
         client_subcommand: "TRACKING",
         status: "ON" | "OFF",
-        redirect_client_id?: ["REDIRECT", number],
-        prefix?: Array<["PREFIX", string]>,
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        bcast?: "BCAST",
+        optin?: "OPTIN",
+        optout?: "OPTOUT",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        optout?: "OPTOUT",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        optin?: "OPTIN",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        optin?: "OPTIN",
+        optout?: "OPTOUT",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        bcast?: "BCAST",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        bcast?: "BCAST",
+        optout?: "OPTOUT",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
+        bcast?: "BCAST",
+        optin?: "OPTIN",
+        noloop?: "NOLOOP"
+    ): Promise<unknown>;
+
+    /**
+     * Enable or disable server assisted client side caching support
+     * - _group_: connection
+     * - _complexity_: O(1)
+     * - _since_: 6.0.0
+     *
+     * [Full docs](https://redis.io/commands/client-tracking)
+     */
+    client(
+        client_subcommand: "TRACKING",
+        status: "ON" | "OFF",
+        redirect?: [redirect: "REDIRECT", client_id: number],
+        prefix?: Array<[prefix: "PREFIX", prefix: string]>,
         bcast?: "BCAST",
         optin?: "OPTIN",
         optout?: "OPTOUT",
@@ -1959,7 +1965,10 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/geoadd)
      */
-    geoadd(key: string, ...longitude_latitude_member: Array<[number, number, string]>): Promise<number>;
+    geoadd(
+        key: string,
+        ...longitude_latitude_member: Array<[longitude: number, latitude: number, member: string]>
+    ): Promise<number>;
 
     /**
      * Returns members of a geospatial index as standard geohash strings
@@ -2005,7 +2014,7 @@ export interface Commands {
         latitude: number,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2022,26 +2031,8 @@ export interface Commands {
         latitude: number,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2059,8 +2050,7 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2077,46 +2067,9 @@ export interface Commands {
         latitude: number,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2133,10 +2086,66 @@ export interface Commands {
         latitude: number,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2154,7 +2163,7 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2172,27 +2181,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2211,8 +2201,7 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2230,8 +2219,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2249,9 +2239,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2269,9 +2258,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2289,10 +2278,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2309,165 +2297,11 @@ export interface Commands {
         latitude: number,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2485,9 +2319,145 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
-        withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2506,8 +2476,27 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2527,8 +2516,7 @@ export interface Commands {
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2547,8 +2535,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2567,9 +2556,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2588,9 +2576,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2609,10 +2597,31 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2630,7 +2639,7 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2648,8 +2657,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2668,7 +2677,7 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2687,8 +2696,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2706,8 +2715,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2725,9 +2734,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2745,9 +2754,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2765,10 +2774,10 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2787,7 +2796,7 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2806,28 +2815,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2847,8 +2836,7 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2867,8 +2855,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2887,9 +2876,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2908,9 +2896,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2929,10 +2917,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -2950,173 +2937,11 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<Array<unknown>>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadius)
-     */
-    georadius(
-        key: string,
-        longitude: number,
-        latitude: number,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3135,9 +2960,152 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
-        withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3157,8 +3125,28 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3179,8 +3167,7 @@ export interface Commands {
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3200,8 +3187,9 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3221,9 +3209,8 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3243,9 +3230,9 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3265,10 +3252,32 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<Array<unknown>>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadius)
+     */
+    georadius(
+        key: string,
+        longitude: number,
+        latitude: number,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -3284,7 +3293,7 @@ export interface Commands {
         member: string,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3300,25 +3309,8 @@ export interface Commands {
         member: string,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3335,8 +3327,7 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3352,44 +3343,9 @@ export interface Commands {
         member: string,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3405,10 +3361,63 @@ export interface Commands {
         member: string,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3425,7 +3434,7 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3442,26 +3451,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3479,8 +3470,7 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3497,8 +3487,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3515,9 +3506,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3534,9 +3524,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3553,10 +3543,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3572,157 +3561,11 @@ export interface Commands {
         member: string,
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3739,9 +3582,138 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
-        withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3759,8 +3731,26 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3779,8 +3769,7 @@ export interface Commands {
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3798,8 +3787,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3817,9 +3807,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3837,9 +3826,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3857,10 +3846,30 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3877,7 +3886,7 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3894,8 +3903,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3913,7 +3922,7 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3931,8 +3940,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3949,8 +3958,8 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3967,9 +3976,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -3986,9 +3995,9 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4005,10 +4014,10 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4026,7 +4035,7 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4044,27 +4053,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4083,8 +4073,7 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4102,8 +4091,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4121,9 +4111,8 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4141,9 +4130,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4161,10 +4150,9 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4181,165 +4169,11 @@ export interface Commands {
         radius: number,
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        count?: ["COUNT", number],
-        order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        storedist_key?: ["STOREDIST", string]
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4357,9 +4191,145 @@ export interface Commands {
         unit: "m" | "km" | "ft" | "mi",
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
-        withhash?: "WITHHASH",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4378,8 +4348,27 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4399,8 +4388,7 @@ export interface Commands {
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4419,50 +4407,9 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        withhash?: "WITHHASH",
-        count?: ["COUNT", number],
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
-    ): Promise<unknown>;
-
-    /**
-     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
-     * - _group_: geo
-     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
-     * - _since_: 3.2.0
-     *
-     * [Full docs](https://redis.io/commands/georadiusbymember)
-     */
-    georadiusbymember(
-        key: string,
-        member: string,
-        radius: number,
-        unit: "m" | "km" | "ft" | "mi",
-        withcoord?: "WITHCOORD",
-        withdist?: "WITHDIST",
-        withhash?: "WITHHASH",
-        count?: ["COUNT", number],
         order?: "ASC" | "DESC",
-        storedist_key?: ["STOREDIST", string]
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4481,10 +4428,72 @@ export interface Commands {
         withcoord?: "WITHCOORD",
         withdist?: "WITHDIST",
         withhash?: "WITHHASH",
-        count?: ["COUNT", number],
+        count?: [count: "COUNT", count: number],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        count?: [count: "COUNT", count: number],
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        count?: [count: "COUNT", count: number],
         order?: "ASC" | "DESC",
-        store_key?: ["STORE", string],
-        storedist_key?: ["STOREDIST", string]
+        storedist?: [storedist: "STOREDIST", key: string]
+    ): Promise<unknown>;
+
+    /**
+     * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
+     * - _group_: geo
+     * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
+     * - _since_: 3.2.0
+     *
+     * [Full docs](https://redis.io/commands/georadiusbymember)
+     */
+    georadiusbymember(
+        key: string,
+        member: string,
+        radius: number,
+        unit: "m" | "km" | "ft" | "mi",
+        withcoord?: "WITHCOORD",
+        withdist?: "WITHDIST",
+        withhash?: "WITHHASH",
+        count?: [count: "COUNT", count: number],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", key: string],
+        storedist?: [storedist: "STOREDIST", key: string]
     ): Promise<unknown>;
 
     /**
@@ -4545,7 +4554,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/hello)
      */
-    hello(protover: number, setname_clientname?: ["SETNAME", string]): Promise<Array<unknown>>;
+    hello(protover: number, setname?: [setname: "SETNAME", clientname: string]): Promise<Array<unknown>>;
 
     /**
      * switch Redis protocol
@@ -4557,8 +4566,8 @@ export interface Commands {
      */
     hello(
         protover: number,
-        auth_username_password?: ["AUTH", [string, string]],
-        setname_clientname?: ["SETNAME", string]
+        auth?: [auth: "AUTH", username_password: [username: string, password: string]],
+        setname?: [setname: "SETNAME", clientname: string]
     ): Promise<Array<unknown>>;
 
     /**
@@ -4649,7 +4658,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/hmset)
      */
-    hmset(key: string, ...field_value: Array<[string, string]>): Promise<"OK">;
+    hmset(key: string, ...field_value: Array<[field: string, value: string]>): Promise<"OK">;
 
     /**
      * Set the string value of a hash field
@@ -4659,7 +4668,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/hset)
      */
-    hset(key: string, ...field_value: Array<[string, string]>): Promise<number>;
+    hset(key: string, ...field_value: Array<[field: string, value: string]>): Promise<number>;
 
     /**
      * Set the value of a hash field, only if the field does not exist
@@ -4739,7 +4748,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/lolwut)
      */
-    lolwut(version?: ["VERSION", number]): Promise<string>;
+    lolwut(version?: [version: "VERSION", version: number]): Promise<string>;
 
     /**
      * Find all keys matching the given pattern
@@ -4809,7 +4818,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/lpos)
      */
-    lpos(key: string, element: string, maxlen_len?: ["MAXLEN", number]): Promise<unknown>;
+    lpos(key: string, element: string, maxlen?: [maxlen: "MAXLEN", len: number]): Promise<unknown>;
 
     /**
      * Return the index of matching elements on a list
@@ -4822,8 +4831,8 @@ export interface Commands {
     lpos(
         key: string,
         element: string,
-        count_num_matches?: ["COUNT", number],
-        maxlen_len?: ["MAXLEN", number]
+        count?: [count: "COUNT", num_matches: number],
+        maxlen?: [maxlen: "MAXLEN", len: number]
     ): Promise<unknown>;
 
     /**
@@ -4834,7 +4843,12 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/lpos)
      */
-    lpos(key: string, element: string, rank?: ["RANK", number], maxlen_len?: ["MAXLEN", number]): Promise<unknown>;
+    lpos(
+        key: string,
+        element: string,
+        rank?: [rank: "RANK", rank: number],
+        maxlen?: [maxlen: "MAXLEN", len: number]
+    ): Promise<unknown>;
 
     /**
      * Return the index of matching elements on a list
@@ -4847,9 +4861,9 @@ export interface Commands {
     lpos(
         key: string,
         element: string,
-        rank?: ["RANK", number],
-        count_num_matches?: ["COUNT", number],
-        maxlen_len?: ["MAXLEN", number]
+        rank?: [rank: "RANK", rank: number],
+        count?: [count: "COUNT", num_matches: number],
+        maxlen?: [maxlen: "MAXLEN", len: number]
     ): Promise<unknown>;
 
     /**
@@ -4970,7 +4984,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/memory-usage)
      */
-    memory(memory_subcommand: "USAGE", key: string, samples_count?: ["SAMPLES", number]): Promise<unknown>;
+    memory(memory_subcommand: "USAGE", key: string, samples?: [samples: "SAMPLES", count: number]): Promise<unknown>;
 
     /**
      * Get the values of all the given keys
@@ -4996,7 +5010,7 @@ export interface Commands {
         key: "key" | '""',
         destination_db: number,
         timeout: number,
-        keys?: ["KEYS", Array<string>]
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5013,8 +5027,8 @@ export interface Commands {
         key: "key" | '""',
         destination_db: number,
         timeout: number,
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5031,8 +5045,8 @@ export interface Commands {
         key: "key" | '""',
         destination_db: number,
         timeout: number,
-        auth_password?: ["AUTH", string],
-        keys?: ["KEYS", Array<string>]
+        auth?: [auth: "AUTH", password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5049,27 +5063,9 @@ export interface Commands {
         key: "key" | '""',
         destination_db: number,
         timeout: number,
-        auth_password?: ["AUTH", string],
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
-    ): Promise<"OK">;
-
-    /**
-     * Atomically transfer a key from a Redis instance to another one.
-     * - _group_: generic
-     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
-     * - _since_: 2.6.0
-     *
-     * [Full docs](https://redis.io/commands/migrate)
-     */
-    migrate(
-        host: string,
-        port: string,
-        key: "key" | '""',
-        destination_db: number,
-        timeout: number,
-        replace?: "REPLACE",
-        keys?: ["KEYS", Array<string>]
+        auth?: [auth: "AUTH", password: string],
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5087,8 +5083,7 @@ export interface Commands {
         destination_db: number,
         timeout: number,
         replace?: "REPLACE",
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5106,8 +5101,8 @@ export interface Commands {
         destination_db: number,
         timeout: number,
         replace?: "REPLACE",
-        auth_password?: ["AUTH", string],
-        keys?: ["KEYS", Array<string>]
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5125,9 +5120,8 @@ export interface Commands {
         destination_db: number,
         timeout: number,
         replace?: "REPLACE",
-        auth_password?: ["AUTH", string],
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
+        auth?: [auth: "AUTH", password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5144,85 +5138,86 @@ export interface Commands {
         key: "key" | '""',
         destination_db: number,
         timeout: number,
-        copy?: "COPY",
-        keys?: ["KEYS", Array<string>]
-    ): Promise<"OK">;
-
-    /**
-     * Atomically transfer a key from a Redis instance to another one.
-     * - _group_: generic
-     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
-     * - _since_: 2.6.0
-     *
-     * [Full docs](https://redis.io/commands/migrate)
-     */
-    migrate(
-        host: string,
-        port: string,
-        key: "key" | '""',
-        destination_db: number,
-        timeout: number,
-        copy?: "COPY",
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
-    ): Promise<"OK">;
-
-    /**
-     * Atomically transfer a key from a Redis instance to another one.
-     * - _group_: generic
-     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
-     * - _since_: 2.6.0
-     *
-     * [Full docs](https://redis.io/commands/migrate)
-     */
-    migrate(
-        host: string,
-        port: string,
-        key: "key" | '""',
-        destination_db: number,
-        timeout: number,
-        copy?: "COPY",
-        auth_password?: ["AUTH", string],
-        keys?: ["KEYS", Array<string>]
-    ): Promise<"OK">;
-
-    /**
-     * Atomically transfer a key from a Redis instance to another one.
-     * - _group_: generic
-     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
-     * - _since_: 2.6.0
-     *
-     * [Full docs](https://redis.io/commands/migrate)
-     */
-    migrate(
-        host: string,
-        port: string,
-        key: "key" | '""',
-        destination_db: number,
-        timeout: number,
-        copy?: "COPY",
-        auth_password?: ["AUTH", string],
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
-    ): Promise<"OK">;
-
-    /**
-     * Atomically transfer a key from a Redis instance to another one.
-     * - _group_: generic
-     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
-     * - _since_: 2.6.0
-     *
-     * [Full docs](https://redis.io/commands/migrate)
-     */
-    migrate(
-        host: string,
-        port: string,
-        key: "key" | '""',
-        destination_db: number,
-        timeout: number,
-        copy?: "COPY",
         replace?: "REPLACE",
-        keys?: ["KEYS", Array<string>]
+        auth?: [auth: "AUTH", password: string],
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
+    ): Promise<"OK">;
+
+    /**
+     * Atomically transfer a key from a Redis instance to another one.
+     * - _group_: generic
+     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
+     * - _since_: 2.6.0
+     *
+     * [Full docs](https://redis.io/commands/migrate)
+     */
+    migrate(
+        host: string,
+        port: string,
+        key: "key" | '""',
+        destination_db: number,
+        timeout: number,
+        copy?: "COPY",
+        keys?: [keys: "KEYS", array_string: Array<string>]
+    ): Promise<"OK">;
+
+    /**
+     * Atomically transfer a key from a Redis instance to another one.
+     * - _group_: generic
+     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
+     * - _since_: 2.6.0
+     *
+     * [Full docs](https://redis.io/commands/migrate)
+     */
+    migrate(
+        host: string,
+        port: string,
+        key: "key" | '""',
+        destination_db: number,
+        timeout: number,
+        copy?: "COPY",
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
+    ): Promise<"OK">;
+
+    /**
+     * Atomically transfer a key from a Redis instance to another one.
+     * - _group_: generic
+     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
+     * - _since_: 2.6.0
+     *
+     * [Full docs](https://redis.io/commands/migrate)
+     */
+    migrate(
+        host: string,
+        port: string,
+        key: "key" | '""',
+        destination_db: number,
+        timeout: number,
+        copy?: "COPY",
+        auth?: [auth: "AUTH", password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
+    ): Promise<"OK">;
+
+    /**
+     * Atomically transfer a key from a Redis instance to another one.
+     * - _group_: generic
+     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
+     * - _since_: 2.6.0
+     *
+     * [Full docs](https://redis.io/commands/migrate)
+     */
+    migrate(
+        host: string,
+        port: string,
+        key: "key" | '""',
+        destination_db: number,
+        timeout: number,
+        copy?: "COPY",
+        auth?: [auth: "AUTH", password: string],
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5241,8 +5236,7 @@ export interface Commands {
         timeout: number,
         copy?: "COPY",
         replace?: "REPLACE",
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5261,8 +5255,8 @@ export interface Commands {
         timeout: number,
         copy?: "COPY",
         replace?: "REPLACE",
-        auth_password?: ["AUTH", string],
-        keys?: ["KEYS", Array<string>]
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5281,9 +5275,29 @@ export interface Commands {
         timeout: number,
         copy?: "COPY",
         replace?: "REPLACE",
-        auth_password?: ["AUTH", string],
-        auth_2_username_password?: ["AUTH2", string],
-        keys?: ["KEYS", Array<string>]
+        auth?: [auth: "AUTH", password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
+    ): Promise<"OK">;
+
+    /**
+     * Atomically transfer a key from a Redis instance to another one.
+     * - _group_: generic
+     * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
+     * - _since_: 2.6.0
+     *
+     * [Full docs](https://redis.io/commands/migrate)
+     */
+    migrate(
+        host: string,
+        port: string,
+        key: "key" | '""',
+        destination_db: number,
+        timeout: number,
+        copy?: "COPY",
+        replace?: "REPLACE",
+        auth?: [auth: "AUTH", password: string],
+        auth_2?: [auth_2: "AUTH2", username_password: string],
+        keys?: [keys: "KEYS", array_string: Array<string>]
     ): Promise<"OK">;
 
     /**
@@ -5344,7 +5358,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/mset)
      */
-    mset(...key_value: Array<[string, string]>): Promise<"OK">;
+    mset(...key_value: Array<[key: string, value: string]>): Promise<"OK">;
 
     /**
      * Set multiple keys to multiple values, only if none of the keys exist
@@ -5354,7 +5368,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/msetnx)
      */
-    msetnx(...key_value: Array<[string, string]>): Promise<number>;
+    msetnx(...key_value: Array<[key: string, value: string]>): Promise<number>;
 
     /**
      * Mark the start of a transaction block
@@ -5464,7 +5478,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/psubscribe)
      */
-    psubscribe(...pattern: Array<[string]>): Promise<unknown>;
+    psubscribe(...pattern: Array<[pattern: string]>): Promise<unknown>;
 
     /**
      * Inspect the state of the Pub/Sub subsystem
@@ -5584,7 +5598,12 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/restore)
      */
-    restore(key: string, ttl: number, serialized_value: string, freq_frequency?: ["FREQ", number]): Promise<"OK">;
+    restore(
+        key: string,
+        ttl: number,
+        serialized_value: string,
+        freq?: [freq: "FREQ", frequency: number]
+    ): Promise<"OK">;
 
     /**
      * Create a key using the provided serialized value, previously obtained using DUMP.
@@ -5598,8 +5617,8 @@ export interface Commands {
         key: string,
         ttl: number,
         serialized_value: string,
-        idletime_seconds?: ["IDLETIME", number],
-        freq_frequency?: ["FREQ", number]
+        idletime?: [idletime: "IDLETIME", seconds: number],
+        freq?: [freq: "FREQ", frequency: number]
     ): Promise<"OK">;
 
     /**
@@ -5615,7 +5634,7 @@ export interface Commands {
         ttl: number,
         serialized_value: string,
         absttl?: "ABSTTL",
-        freq_frequency?: ["FREQ", number]
+        freq?: [freq: "FREQ", frequency: number]
     ): Promise<"OK">;
 
     /**
@@ -5631,8 +5650,8 @@ export interface Commands {
         ttl: number,
         serialized_value: string,
         absttl?: "ABSTTL",
-        idletime_seconds?: ["IDLETIME", number],
-        freq_frequency?: ["FREQ", number]
+        idletime?: [idletime: "IDLETIME", seconds: number],
+        freq?: [freq: "FREQ", frequency: number]
     ): Promise<"OK">;
 
     /**
@@ -5648,7 +5667,7 @@ export interface Commands {
         ttl: number,
         serialized_value: string,
         replace?: "REPLACE",
-        freq_frequency?: ["FREQ", number]
+        freq?: [freq: "FREQ", frequency: number]
     ): Promise<"OK">;
 
     /**
@@ -5664,25 +5683,8 @@ export interface Commands {
         ttl: number,
         serialized_value: string,
         replace?: "REPLACE",
-        idletime_seconds?: ["IDLETIME", number],
-        freq_frequency?: ["FREQ", number]
-    ): Promise<"OK">;
-
-    /**
-     * Create a key using the provided serialized value, previously obtained using DUMP.
-     * - _group_: generic
-     * - _complexity_: O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).
-     * - _since_: 2.6.0
-     *
-     * [Full docs](https://redis.io/commands/restore)
-     */
-    restore(
-        key: string,
-        ttl: number,
-        serialized_value: string,
-        replace?: "REPLACE",
-        absttl?: "ABSTTL",
-        freq_frequency?: ["FREQ", number]
+        idletime?: [idletime: "IDLETIME", seconds: number],
+        freq?: [freq: "FREQ", frequency: number]
     ): Promise<"OK">;
 
     /**
@@ -5699,8 +5701,25 @@ export interface Commands {
         serialized_value: string,
         replace?: "REPLACE",
         absttl?: "ABSTTL",
-        idletime_seconds?: ["IDLETIME", number],
-        freq_frequency?: ["FREQ", number]
+        freq?: [freq: "FREQ", frequency: number]
+    ): Promise<"OK">;
+
+    /**
+     * Create a key using the provided serialized value, previously obtained using DUMP.
+     * - _group_: generic
+     * - _complexity_: O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).
+     * - _since_: 2.6.0
+     *
+     * [Full docs](https://redis.io/commands/restore)
+     */
+    restore(
+        key: string,
+        ttl: number,
+        serialized_value: string,
+        replace?: "REPLACE",
+        absttl?: "ABSTTL",
+        idletime?: [idletime: "IDLETIME", seconds: number],
+        freq?: [freq: "FREQ", frequency: number]
     ): Promise<"OK">;
 
     /**
@@ -5904,7 +5923,7 @@ export interface Commands {
     set(
         key: string,
         value: string,
-        expiration?: ["EX" | "PX", number] | "KEEPTTL",
+        expiration?: [ex_px: "EX" | "PX", number: number] | "KEEPTTL",
         get?: "GET"
     ): Promise<"OK" | string | null>;
 
@@ -5919,7 +5938,7 @@ export interface Commands {
     set(
         key: string,
         value: string,
-        expiration?: ["EX" | "PX", number] | "KEEPTTL",
+        expiration?: [ex_px: "EX" | "PX", number: number] | "KEEPTTL",
         condition?: "NX" | "XX",
         get?: "GET"
     ): Promise<"OK" | string | null>;
@@ -6072,7 +6091,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/sort)
      */
-    sort(key: string, store_destination?: ["STORE", string]): Promise<number | Array<unknown>>;
+    sort(key: string, store?: [store: "STORE", destination: string]): Promise<number | Array<unknown>>;
 
     /**
      * Sort the elements in a list, set or sorted set
@@ -6082,7 +6101,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/sort)
      */
-    sort(key: string, sorting?: "ALPHA", store_destination?: ["STORE", string]): Promise<number | Array<unknown>>;
+    sort(
+        key: string,
+        sorting?: "ALPHA",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
 
     /**
      * Sort the elements in a list, set or sorted set
@@ -6092,7 +6115,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/sort)
      */
-    sort(key: string, order?: "ASC" | "DESC", store_destination?: ["STORE", string]): Promise<number | Array<unknown>>;
+    sort(
+        key: string,
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
 
     /**
      * Sort the elements in a list, set or sorted set
@@ -6106,7 +6133,7 @@ export interface Commands {
         key: string,
         order?: "ASC" | "DESC",
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6119,8 +6146,8 @@ export interface Commands {
      */
     sort(
         key: string,
-        get_pattern?: Array<["GET", string]>,
-        store_destination?: ["STORE", string]
+        get?: Array<[get: "GET", pattern: string]>,
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6133,9 +6160,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        get_pattern?: Array<["GET", string]>,
+        get?: Array<[get: "GET", pattern: string]>,
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6148,9 +6175,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        get_pattern?: Array<["GET", string]>,
+        get?: Array<[get: "GET", pattern: string]>,
         order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6163,70 +6190,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        get_pattern?: Array<["GET", string]>,
-        order?: "ASC" | "DESC",
-        sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
+        get?: Array<[get: "GET", pattern: string]>,
         order?: "ASC" | "DESC",
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6239,9 +6206,8 @@ export interface Commands {
      */
     sort(
         key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
-        store_destination?: ["STORE", string]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6254,10 +6220,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6270,10 +6235,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
         order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6286,11 +6250,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
         order?: "ASC" | "DESC",
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6303,8 +6266,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        store_destination?: ["STORE", string]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6317,9 +6281,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6332,9 +6297,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
         order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6347,74 +6313,11 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        order?: "ASC" | "DESC",
-        sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        by_pattern?: ["BY", string],
-        get_pattern?: Array<["GET", string]>,
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        by_pattern?: ["BY", string],
-        get_pattern?: Array<["GET", string]>,
-        sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        by_pattern?: ["BY", string],
-        get_pattern?: Array<["GET", string]>,
-        order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
-    ): Promise<number | Array<unknown>>;
-
-    /**
-     * Sort the elements in a list, set or sorted set
-     * - _group_: generic
-     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
-     * - _since_: 1.0.0
-     *
-     * [Full docs](https://redis.io/commands/sort)
-     */
-    sort(
-        key: string,
-        by_pattern?: ["BY", string],
-        get_pattern?: Array<["GET", string]>,
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
         order?: "ASC" | "DESC",
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6427,9 +6330,8 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
-        store_destination?: ["STORE", string]
+        by?: [by: "BY", pattern: string],
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6442,10 +6344,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
+        by?: [by: "BY", pattern: string],
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6458,10 +6359,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
+        by?: [by: "BY", pattern: string],
         order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6474,11 +6374,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
+        by?: [by: "BY", pattern: string],
         order?: "ASC" | "DESC",
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6491,10 +6390,9 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
-        store_destination?: ["STORE", string]
+        by?: [by: "BY", pattern: string],
+        get?: Array<[get: "GET", pattern: string]>,
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6507,11 +6405,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
+        by?: [by: "BY", pattern: string],
+        get?: Array<[get: "GET", pattern: string]>,
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6524,11 +6421,10 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
+        by?: [by: "BY", pattern: string],
+        get?: Array<[get: "GET", pattern: string]>,
         order?: "ASC" | "DESC",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6541,12 +6437,143 @@ export interface Commands {
      */
     sort(
         key: string,
-        by_pattern?: ["BY", string],
-        limit_offset_count?: ["LIMIT", [number, number]],
-        get_pattern?: Array<["GET", string]>,
+        by?: [by: "BY", pattern: string],
+        get?: Array<[get: "GET", pattern: string]>,
         order?: "ASC" | "DESC",
         sorting?: "ALPHA",
-        store_destination?: ["STORE", string]
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        sorting?: "ALPHA",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        order?: "ASC" | "DESC",
+        sorting?: "ALPHA",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
+        sorting?: "ALPHA",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
+        order?: "ASC" | "DESC",
+        store?: [store: "STORE", destination: string]
+    ): Promise<number | Array<unknown>>;
+
+    /**
+     * Sort the elements in a list, set or sorted set
+     * - _group_: generic
+     * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.
+     * - _since_: 1.0.0
+     *
+     * [Full docs](https://redis.io/commands/sort)
+     */
+    sort(
+        key: string,
+        by?: [by: "BY", pattern: string],
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]],
+        get?: Array<[get: "GET", pattern: string]>,
+        order?: "ASC" | "DESC",
+        sorting?: "ALPHA",
+        store?: [store: "STORE", destination: string]
     ): Promise<number | Array<unknown>>;
 
     /**
@@ -6757,7 +6784,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zadd)
      */
-    zadd(key: string, ...score_member: Array<[number, string]>): Promise<number | string | null>;
+    zadd(key: string, ...score_member: Array<[score: number, member: string]>): Promise<number | string | null>;
 
     /**
      * Add one or more members to a sorted set, or update its score if it already exists
@@ -6767,7 +6794,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zadd)
      */
-    zadd(key: string, increment: "INCR", ...score_member: Array<[number, string]>): Promise<number | string | null>;
+    zadd(
+        key: string,
+        increment: "INCR",
+        ...score_member: Array<[score: number, member: string]>
+    ): Promise<number | string | null>;
 
     /**
      * Add one or more members to a sorted set, or update its score if it already exists
@@ -6777,7 +6808,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zadd)
      */
-    zadd(key: string, change: "CH", ...score_member: Array<[number, string]>): Promise<number | string | null>;
+    zadd(
+        key: string,
+        change: "CH",
+        ...score_member: Array<[score: number, member: string]>
+    ): Promise<number | string | null>;
 
     /**
      * Add one or more members to a sorted set, or update its score if it already exists
@@ -6791,7 +6826,7 @@ export interface Commands {
         key: string,
         change: "CH",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6805,7 +6840,7 @@ export interface Commands {
     zadd(
         key: string,
         comparison: "GT" | "LT",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6820,22 +6855,7 @@ export interface Commands {
         key: string,
         comparison: "GT" | "LT",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
-    ): Promise<number | string | null>;
-
-    /**
-     * Add one or more members to a sorted set, or update its score if it already exists
-     * - _group_: sorted_set
-     * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.
-     * - _since_: 1.2.0
-     *
-     * [Full docs](https://redis.io/commands/zadd)
-     */
-    zadd(
-        key: string,
-        comparison: "GT" | "LT",
-        change: "CH",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6850,8 +6870,23 @@ export interface Commands {
         key: string,
         comparison: "GT" | "LT",
         change: "CH",
+        ...score_member: Array<[score: number, member: string]>
+    ): Promise<number | string | null>;
+
+    /**
+     * Add one or more members to a sorted set, or update its score if it already exists
+     * - _group_: sorted_set
+     * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.
+     * - _since_: 1.2.0
+     *
+     * [Full docs](https://redis.io/commands/zadd)
+     */
+    zadd(
+        key: string,
+        comparison: "GT" | "LT",
+        change: "CH",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6865,7 +6900,7 @@ export interface Commands {
     zadd(
         key: string,
         condition: "NX" | "XX",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6880,7 +6915,7 @@ export interface Commands {
         key: string,
         condition: "NX" | "XX",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6895,7 +6930,7 @@ export interface Commands {
         key: string,
         condition: "NX" | "XX",
         change: "CH",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6911,7 +6946,7 @@ export interface Commands {
         condition: "NX" | "XX",
         change: "CH",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6926,7 +6961,7 @@ export interface Commands {
         key: string,
         condition: "NX" | "XX",
         comparison: "GT" | "LT",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6942,23 +6977,7 @@ export interface Commands {
         condition: "NX" | "XX",
         comparison: "GT" | "LT",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
-    ): Promise<number | string | null>;
-
-    /**
-     * Add one or more members to a sorted set, or update its score if it already exists
-     * - _group_: sorted_set
-     * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.
-     * - _since_: 1.2.0
-     *
-     * [Full docs](https://redis.io/commands/zadd)
-     */
-    zadd(
-        key: string,
-        condition: "NX" | "XX",
-        comparison: "GT" | "LT",
-        change: "CH",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -6974,8 +6993,24 @@ export interface Commands {
         condition: "NX" | "XX",
         comparison: "GT" | "LT",
         change: "CH",
+        ...score_member: Array<[score: number, member: string]>
+    ): Promise<number | string | null>;
+
+    /**
+     * Add one or more members to a sorted set, or update its score if it already exists
+     * - _group_: sorted_set
+     * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.
+     * - _since_: 1.2.0
+     *
+     * [Full docs](https://redis.io/commands/zadd)
+     */
+    zadd(
+        key: string,
+        condition: "NX" | "XX",
+        comparison: "GT" | "LT",
+        change: "CH",
         increment: "INCR",
-        ...score_member: Array<[number, string]>
+        ...score_member: Array<[score: number, member: string]>
     ): Promise<number | string | null>;
 
     /**
@@ -7053,7 +7088,7 @@ export interface Commands {
     zinter(
         numkeys: number,
         key: Array<string>,
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"],
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"],
         withscores?: "WITHSCORES"
     ): Promise<Array<unknown>>;
 
@@ -7068,7 +7103,7 @@ export interface Commands {
     zinter(
         numkeys: number,
         key: Array<string>,
-        weights?: ["WEIGHTS", Array<number>],
+        weights?: [weights: "WEIGHTS", array_number: Array<number>],
         withscores?: "WITHSCORES"
     ): Promise<Array<unknown>>;
 
@@ -7083,8 +7118,8 @@ export interface Commands {
     zinter(
         numkeys: number,
         key: Array<string>,
-        weights?: ["WEIGHTS", Array<number>],
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"],
+        weights?: [weights: "WEIGHTS", array_number: Array<number>],
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"],
         withscores?: "WITHSCORES"
     ): Promise<Array<unknown>>;
 
@@ -7100,7 +7135,7 @@ export interface Commands {
         destination: string,
         numkeys: number,
         key: Array<string>,
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"]
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"]
     ): Promise<number>;
 
     /**
@@ -7115,8 +7150,8 @@ export interface Commands {
         destination: string,
         numkeys: number,
         key: Array<string>,
-        weights?: ["WEIGHTS", Array<number>],
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"]
+        weights?: [weights: "WEIGHTS", array_number: Array<number>],
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"]
     ): Promise<number>;
 
     /**
@@ -7171,7 +7206,7 @@ export interface Commands {
         key: string,
         min: string,
         max: string,
-        limit_offset_count?: ["LIMIT", [number, number]]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]]
     ): Promise<Array<string>>;
 
     /**
@@ -7186,7 +7221,7 @@ export interface Commands {
         key: string,
         max: string,
         min: string,
-        limit_offset_count?: ["LIMIT", [number, number]]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]]
     ): Promise<Array<string>>;
 
     /**
@@ -7201,7 +7236,7 @@ export interface Commands {
         key: string,
         min: number | ("-inf" | "+inf") | string,
         max: number | ("-inf" | "+inf") | string,
-        limit_offset_count?: ["LIMIT", [number, number]]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]]
     ): Promise<Array<string>>;
 
     /**
@@ -7217,7 +7252,7 @@ export interface Commands {
         min: number | ("-inf" | "+inf") | string,
         max: number | ("-inf" | "+inf") | string,
         withscores?: "WITHSCORES",
-        limit_offset_count?: ["LIMIT", [number, number]]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]]
     ): Promise<Array<string>>;
 
     /**
@@ -7296,7 +7331,7 @@ export interface Commands {
         key: string,
         max: number | ("-inf" | "+inf") | string,
         min: number | ("-inf" | "+inf") | string,
-        limit_offset_count?: ["LIMIT", [number, number]]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]]
     ): Promise<Array<unknown>>;
 
     /**
@@ -7312,7 +7347,7 @@ export interface Commands {
         max: number | ("-inf" | "+inf") | string,
         min: number | ("-inf" | "+inf") | string,
         withscores?: "WITHSCORES",
-        limit_offset_count?: ["LIMIT", [number, number]]
+        limit?: [limit: "LIMIT", offset_count: [offset: number, count: number]]
     ): Promise<Array<unknown>>;
 
     /**
@@ -7356,7 +7391,7 @@ export interface Commands {
     zunion(
         numkeys: number,
         key: Array<string>,
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"],
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"],
         withscores?: "WITHSCORES"
     ): Promise<Array<unknown>>;
 
@@ -7371,7 +7406,7 @@ export interface Commands {
     zunion(
         numkeys: number,
         key: Array<string>,
-        weights?: ["WEIGHTS", Array<number>],
+        weights?: [weights: "WEIGHTS", array_number: Array<number>],
         withscores?: "WITHSCORES"
     ): Promise<Array<unknown>>;
 
@@ -7386,8 +7421,8 @@ export interface Commands {
     zunion(
         numkeys: number,
         key: Array<string>,
-        weights?: ["WEIGHTS", Array<number>],
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"],
+        weights?: [weights: "WEIGHTS", array_number: Array<number>],
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"],
         withscores?: "WITHSCORES"
     ): Promise<Array<unknown>>;
 
@@ -7413,7 +7448,7 @@ export interface Commands {
         destination: string,
         numkeys: number,
         key: Array<string>,
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"]
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"]
     ): Promise<number>;
 
     /**
@@ -7428,8 +7463,8 @@ export interface Commands {
         destination: string,
         numkeys: number,
         key: Array<string>,
-        weights?: ["WEIGHTS", Array<number>],
-        aggregate?: ["AGGREGATE", "SUM" | "MIN" | "MAX"]
+        weights?: [weights: "WEIGHTS", array_number: Array<number>],
+        aggregate?: [aggregate: "AGGREGATE", aggregate: "SUM" | "MIN" | "MAX"]
     ): Promise<number>;
 
     /**
@@ -7440,27 +7475,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/scan)
      */
-    scan(cursor: number, type?: ["TYPE", string]): Promise<unknown>;
-
-    /**
-     * Incrementally iterate the keys space
-     * - _group_: generic
-     * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.
-     * - _since_: 2.8.0
-     *
-     * [Full docs](https://redis.io/commands/scan)
-     */
-    scan(cursor: number, count?: ["COUNT", number], type?: ["TYPE", string]): Promise<unknown>;
-
-    /**
-     * Incrementally iterate the keys space
-     * - _group_: generic
-     * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.
-     * - _since_: 2.8.0
-     *
-     * [Full docs](https://redis.io/commands/scan)
-     */
-    scan(cursor: number, match_pattern?: ["MATCH", string], type?: ["TYPE", string]): Promise<unknown>;
+    scan(cursor: number, type?: [type: "TYPE", type: string]): Promise<unknown>;
 
     /**
      * Incrementally iterate the keys space
@@ -7472,9 +7487,37 @@ export interface Commands {
      */
     scan(
         cursor: number,
-        match_pattern?: ["MATCH", string],
-        count?: ["COUNT", number],
-        type?: ["TYPE", string]
+        count?: [count: "COUNT", count: number],
+        type?: [type: "TYPE", type: string]
+    ): Promise<unknown>;
+
+    /**
+     * Incrementally iterate the keys space
+     * - _group_: generic
+     * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.
+     * - _since_: 2.8.0
+     *
+     * [Full docs](https://redis.io/commands/scan)
+     */
+    scan(
+        cursor: number,
+        match?: [match: "MATCH", pattern: string],
+        type?: [type: "TYPE", type: string]
+    ): Promise<unknown>;
+
+    /**
+     * Incrementally iterate the keys space
+     * - _group_: generic
+     * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.
+     * - _since_: 2.8.0
+     *
+     * [Full docs](https://redis.io/commands/scan)
+     */
+    scan(
+        cursor: number,
+        match?: [match: "MATCH", pattern: string],
+        count?: [count: "COUNT", count: number],
+        type?: [type: "TYPE", type: string]
     ): Promise<unknown>;
 
     /**
@@ -7485,7 +7528,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/sscan)
      */
-    sscan(key: string, cursor: number, count?: ["COUNT", number]): Promise<unknown>;
+    sscan(key: string, cursor: number, count?: [count: "COUNT", count: number]): Promise<unknown>;
 
     /**
      * Incrementally iterate Set elements
@@ -7495,7 +7538,12 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/sscan)
      */
-    sscan(key: string, cursor: number, match_pattern?: ["MATCH", string], count?: ["COUNT", number]): Promise<unknown>;
+    sscan(
+        key: string,
+        cursor: number,
+        match?: [match: "MATCH", pattern: string],
+        count?: [count: "COUNT", count: number]
+    ): Promise<unknown>;
 
     /**
      * Incrementally iterate hash fields and associated values
@@ -7505,7 +7553,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/hscan)
      */
-    hscan(key: string, cursor: number, count?: ["COUNT", number]): Promise<unknown>;
+    hscan(key: string, cursor: number, count?: [count: "COUNT", count: number]): Promise<unknown>;
 
     /**
      * Incrementally iterate hash fields and associated values
@@ -7515,7 +7563,12 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/hscan)
      */
-    hscan(key: string, cursor: number, match_pattern?: ["MATCH", string], count?: ["COUNT", number]): Promise<unknown>;
+    hscan(
+        key: string,
+        cursor: number,
+        match?: [match: "MATCH", pattern: string],
+        count?: [count: "COUNT", count: number]
+    ): Promise<unknown>;
 
     /**
      * Incrementally iterate sorted sets elements and associated scores
@@ -7525,7 +7578,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zscan)
      */
-    zscan(key: string, cursor: number, count?: ["COUNT", number]): Promise<unknown>;
+    zscan(key: string, cursor: number, count?: [count: "COUNT", count: number]): Promise<unknown>;
 
     /**
      * Incrementally iterate sorted sets elements and associated scores
@@ -7535,7 +7588,12 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/zscan)
      */
-    zscan(key: string, cursor: number, match_pattern?: ["MATCH", string], count?: ["COUNT", number]): Promise<unknown>;
+    zscan(
+        key: string,
+        cursor: number,
+        match?: [match: "MATCH", pattern: string],
+        count?: [count: "COUNT", count: number]
+    ): Promise<unknown>;
 
     /**
      * Get information on streams and consumer groups
@@ -7555,7 +7613,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xinfo)
      */
-    xinfo(stream_key?: ["STREAM", string], help?: "HELP"): Promise<unknown>;
+    xinfo(stream?: [stream: "STREAM", key: string], help?: "HELP"): Promise<unknown>;
 
     /**
      * Get information on streams and consumer groups
@@ -7565,27 +7623,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xinfo)
      */
-    xinfo(groups_key?: ["GROUPS", string], help?: "HELP"): Promise<unknown>;
-
-    /**
-     * Get information on streams and consumer groups
-     * - _group_: stream
-     * - _complexity_: O(N) with N being the number of returned items for the subcommands CONSUMERS and GROUPS. The STREAM subcommand is O(log N) with N being the number of items in the stream.
-     * - _since_: 5.0.0
-     *
-     * [Full docs](https://redis.io/commands/xinfo)
-     */
-    xinfo(groups_key?: ["GROUPS", string], stream_key?: ["STREAM", string], help?: "HELP"): Promise<unknown>;
-
-    /**
-     * Get information on streams and consumer groups
-     * - _group_: stream
-     * - _complexity_: O(N) with N being the number of returned items for the subcommands CONSUMERS and GROUPS. The STREAM subcommand is O(log N) with N being the number of items in the stream.
-     * - _since_: 5.0.0
-     *
-     * [Full docs](https://redis.io/commands/xinfo)
-     */
-    xinfo(consumers_key_groupname?: ["CONSUMERS", [string, string]], help?: "HELP"): Promise<unknown>;
+    xinfo(groups?: [groups: "GROUPS", key: string], help?: "HELP"): Promise<unknown>;
 
     /**
      * Get information on streams and consumer groups
@@ -7596,8 +7634,8 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xinfo)
      */
     xinfo(
-        consumers_key_groupname?: ["CONSUMERS", [string, string]],
-        stream_key?: ["STREAM", string],
+        groups?: [groups: "GROUPS", key: string],
+        stream?: [stream: "STREAM", key: string],
         help?: "HELP"
     ): Promise<unknown>;
 
@@ -7610,8 +7648,7 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xinfo)
      */
     xinfo(
-        consumers_key_groupname?: ["CONSUMERS", [string, string]],
-        groups_key?: ["GROUPS", string],
+        consumers?: [consumers: "CONSUMERS", key_groupname: [key: string, groupname: string]],
         help?: "HELP"
     ): Promise<unknown>;
 
@@ -7624,9 +7661,37 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xinfo)
      */
     xinfo(
-        consumers_key_groupname?: ["CONSUMERS", [string, string]],
-        groups_key?: ["GROUPS", string],
-        stream_key?: ["STREAM", string],
+        consumers?: [consumers: "CONSUMERS", key_groupname: [key: string, groupname: string]],
+        stream?: [stream: "STREAM", key: string],
+        help?: "HELP"
+    ): Promise<unknown>;
+
+    /**
+     * Get information on streams and consumer groups
+     * - _group_: stream
+     * - _complexity_: O(N) with N being the number of returned items for the subcommands CONSUMERS and GROUPS. The STREAM subcommand is O(log N) with N being the number of items in the stream.
+     * - _since_: 5.0.0
+     *
+     * [Full docs](https://redis.io/commands/xinfo)
+     */
+    xinfo(
+        consumers?: [consumers: "CONSUMERS", key_groupname: [key: string, groupname: string]],
+        groups?: [groups: "GROUPS", key: string],
+        help?: "HELP"
+    ): Promise<unknown>;
+
+    /**
+     * Get information on streams and consumer groups
+     * - _group_: stream
+     * - _complexity_: O(N) with N being the number of returned items for the subcommands CONSUMERS and GROUPS. The STREAM subcommand is O(log N) with N being the number of items in the stream.
+     * - _since_: 5.0.0
+     *
+     * [Full docs](https://redis.io/commands/xinfo)
+     */
+    xinfo(
+        consumers?: [consumers: "CONSUMERS", key_groupname: [key: string, groupname: string]],
+        groups?: [groups: "GROUPS", key: string],
+        stream?: [stream: "STREAM", key: string],
         help?: "HELP"
     ): Promise<unknown>;
 
@@ -7638,7 +7703,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xadd)
      */
-    xadd(key: string, id: string, ...field_value: Array<[string, string]>): Promise<string>;
+    xadd(key: string, id: string, ...field_value: Array<[field: string, value: string]>): Promise<string>;
 
     /**
      * Trims the stream to (approximately if '~' is passed) a certain size
@@ -7678,7 +7743,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xrange)
      */
-    xrange(key: string, start: string, end: string, count?: ["COUNT", number]): Promise<Array<unknown>>;
+    xrange(key: string, start: string, end: string, count?: [count: "COUNT", count: number]): Promise<Array<unknown>>;
 
     /**
      * Return a range of elements in a stream, with IDs matching the specified IDs interval, in reverse order (from greater to smaller IDs) compared to XRANGE
@@ -7688,7 +7753,12 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xrevrange)
      */
-    xrevrange(key: string, end: string, start: string, count?: ["COUNT", number]): Promise<Array<unknown>>;
+    xrevrange(
+        key: string,
+        end: string,
+        start: string,
+        count?: [count: "COUNT", count: number]
+    ): Promise<Array<unknown>>;
 
     /**
      * Return the number of entries in a stream
@@ -7719,7 +7789,7 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xread)
      */
     xread(
-        block_milliseconds: ["BLOCK", number],
+        block: [block: "BLOCK", milliseconds: number],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -7734,7 +7804,7 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xread)
      */
     xread(
-        count: ["COUNT", number],
+        count: [count: "COUNT", count: number],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -7749,8 +7819,8 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xread)
      */
     xread(
-        count: ["COUNT", number],
-        block_milliseconds: ["BLOCK", number],
+        count: [count: "COUNT", count: number],
+        block: [block: "BLOCK", milliseconds: number],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -7764,19 +7834,11 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xgroup)
      */
-    xgroup(delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]): Promise<unknown>;
-
-    /**
-     * Create, destroy, and manage consumer groups.
-     * - _group_: stream
-     * - _complexity_: O(1) for all the subcommands, with the exception of the DESTROY subcommand which takes an additional O(M) time in order to delete the M entries inside the consumer group pending entries list (PEL).
-     * - _since_: 5.0.0
-     *
-     * [Full docs](https://redis.io/commands/xgroup)
-     */
     xgroup(
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7788,8 +7850,14 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7801,9 +7869,11 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7815,8 +7885,15 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7828,9 +7905,11 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7842,9 +7921,15 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7856,10 +7941,12 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7871,8 +7958,16 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7884,9 +7979,11 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7898,9 +7995,15 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7912,10 +8015,12 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7927,9 +8032,16 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7941,10 +8053,12 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7956,10 +8070,16 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7971,11 +8091,35 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xgroup)
      */
     xgroup(
-        create_key_groupname_id_or?: ["CREATE", [string, string, string]],
-        setid_key_groupname_id_or?: ["SETID", [string, string, string]],
-        destroy_key_groupname?: ["DESTROY", [string, string]],
-        createconsumer_key_groupname_consumername?: ["CREATECONSUMER", [string, string, string]],
-        delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
+    ): Promise<unknown>;
+
+    /**
+     * Create, destroy, and manage consumer groups.
+     * - _group_: stream
+     * - _complexity_: O(1) for all the subcommands, with the exception of the DESTROY subcommand which takes an additional O(M) time in order to delete the M entries inside the consumer group pending entries list (PEL).
+     * - _since_: 5.0.0
+     *
+     * [Full docs](https://redis.io/commands/xgroup)
+     */
+    xgroup(
+        create?: [create: "CREATE", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        setid?: [setid: "SETID", key_groupname_id_or_dollar: [key: string, groupname: string, id_or_dollar: string]],
+        destroy?: [destroy: "DESTROY", key_groupname: [key: string, groupname: string]],
+        createconsumer?: [
+            createconsumer: "CREATECONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ],
+        delconsumer?: [
+            delconsumer: "DELCONSUMER",
+            key_groupname_consumername: [key: string, groupname: string, consumername: string]
+        ]
     ): Promise<unknown>;
 
     /**
@@ -7987,7 +8131,7 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -8002,7 +8146,7 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
         noack: "NOACK",
         streams: "STREAMS",
         key: Array<string>,
@@ -8018,8 +8162,8 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
-        block_milliseconds: ["BLOCK", number],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
+        block: [block: "BLOCK", milliseconds: number],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -8034,8 +8178,8 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
-        block_milliseconds: ["BLOCK", number],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
+        block: [block: "BLOCK", milliseconds: number],
         noack: "NOACK",
         streams: "STREAMS",
         key: Array<string>,
@@ -8051,8 +8195,8 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
-        count: ["COUNT", number],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
+        count: [count: "COUNT", count: number],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -8067,8 +8211,8 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
-        count: ["COUNT", number],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
+        count: [count: "COUNT", count: number],
         noack: "NOACK",
         streams: "STREAMS",
         key: Array<string>,
@@ -8084,9 +8228,9 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
-        count: ["COUNT", number],
-        block_milliseconds: ["BLOCK", number],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
+        count: [count: "COUNT", count: number],
+        block: [block: "BLOCK", milliseconds: number],
         streams: "STREAMS",
         key: Array<string>,
         ...id: Array<string>
@@ -8101,9 +8245,9 @@ export interface Commands {
      * [Full docs](https://redis.io/commands/xreadgroup)
      */
     xreadgroup(
-        group_consumer: ["GROUP", [string, string]],
-        count: ["COUNT", number],
-        block_milliseconds: ["BLOCK", number],
+        group: [group: "GROUP", group_consumer: [group: string, consumer: string]],
+        count: [count: "COUNT", count: number],
+        block: [block: "BLOCK", milliseconds: number],
         noack: "NOACK",
         streams: "STREAMS",
         key: Array<string>,
@@ -8169,7 +8313,7 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        retrycount_count?: ["RETRYCOUNT", number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8187,7 +8331,7 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        retrycount_count?: ["RETRYCOUNT", number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8206,7 +8350,7 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        time_ms_unix_time?: ["TIME", number],
+        time?: [time: "TIME", ms_unix_time: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8224,7 +8368,7 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        time_ms_unix_time?: ["TIME", number],
+        time?: [time: "TIME", ms_unix_time: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8243,8 +8387,8 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        time_ms_unix_time?: ["TIME", number],
-        retrycount_count?: ["RETRYCOUNT", number],
+        time?: [time: "TIME", ms_unix_time: number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8262,8 +8406,8 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        time_ms_unix_time?: ["TIME", number],
-        retrycount_count?: ["RETRYCOUNT", number],
+        time?: [time: "TIME", ms_unix_time: number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8282,7 +8426,7 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
+        idle?: [idle: "IDLE", ms: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8300,7 +8444,7 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
+        idle?: [idle: "IDLE", ms: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8319,8 +8463,8 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
-        retrycount_count?: ["RETRYCOUNT", number],
+        idle?: [idle: "IDLE", ms: number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8338,8 +8482,8 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
-        retrycount_count?: ["RETRYCOUNT", number],
+        idle?: [idle: "IDLE", ms: number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8358,8 +8502,8 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
-        time_ms_unix_time?: ["TIME", number],
+        idle?: [idle: "IDLE", ms: number],
+        time?: [time: "TIME", ms_unix_time: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8377,8 +8521,8 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
-        time_ms_unix_time?: ["TIME", number],
+        idle?: [idle: "IDLE", ms: number],
+        time?: [time: "TIME", ms_unix_time: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8397,9 +8541,9 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
-        time_ms_unix_time?: ["TIME", number],
-        retrycount_count?: ["RETRYCOUNT", number],
+        idle?: [idle: "IDLE", ms: number],
+        time?: [time: "TIME", ms_unix_time: number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         justid?: unknown
     ): Promise<Array<unknown>>;
 
@@ -8417,9 +8561,9 @@ export interface Commands {
         consumer: string,
         min_idle_time: string,
         id: Array<string>,
-        idle_ms?: ["IDLE", number],
-        time_ms_unix_time?: ["TIME", number],
-        retrycount_count?: ["RETRYCOUNT", number],
+        idle?: [idle: "IDLE", ms: number],
+        time?: [time: "TIME", ms_unix_time: number],
+        retrycount?: [retrycount: "RETRYCOUNT", count: number],
         force?: unknown,
         justid?: unknown
     ): Promise<Array<unknown>>;
@@ -8432,7 +8576,7 @@ export interface Commands {
      *
      * [Full docs](https://redis.io/commands/xpending)
      */
-    xpending(key: string, group: string, idle_min_idle_time?: ["IDLE", number]): Promise<Array<unknown>>;
+    xpending(key: string, group: string, idle?: [idle: "IDLE", min_idle_time: number]): Promise<Array<unknown>>;
 
     /**
      * Return information and entries from a stream consumer group pending entries list, that are messages fetched but never acknowledged.
@@ -8446,7 +8590,7 @@ export interface Commands {
         key: string,
         group: string,
         consumer?: string,
-        idle_min_idle_time?: ["IDLE", number]
+        idle?: [idle: "IDLE", min_idle_time: number]
     ): Promise<Array<unknown>>;
 
     /**
@@ -8460,8 +8604,8 @@ export interface Commands {
     xpending(
         key: string,
         group: string,
-        start_end_count?: [string, string, number],
-        idle_min_idle_time?: ["IDLE", number]
+        start_end_count?: [start: string, end: string, count: number],
+        idle?: [idle: "IDLE", min_idle_time: number]
     ): Promise<Array<unknown>>;
 
     /**
@@ -8475,9 +8619,9 @@ export interface Commands {
     xpending(
         key: string,
         group: string,
-        start_end_count?: [string, string, number],
+        start_end_count?: [start: string, end: string, count: number],
         consumer?: string,
-        idle_min_idle_time?: ["IDLE", number]
+        idle?: [idle: "IDLE", min_idle_time: number]
     ): Promise<Array<unknown>>;
 
     /**

--- a/test/generated/commands/hincrbyfloat.test.ts
+++ b/test/generated/commands/hincrbyfloat.test.ts
@@ -20,7 +20,7 @@ test("docs/redis-doc/commands/hincrbyfloat.md example 1", async () => {
     outputs.r3 = await client.hset("mykey", ["field", "5.0e3"]);
     // Error decoding command `HINCRBYFLOAT mykey field 2.0e2`:
 
-    // decoding HINCRBYFLOAT overload 0 (key,field,increment): { name: 'key', schema: { type: 'string' } },{ name: 'field', schema: { type: 'string' } },{ name: 'increment', schema: { type: 'number' } }
+    // decoding HINCRBYFLOAT overload 0 (key,field,increment): { name: 'key', schema: { title: 'key', type: 'string' } },{ name: 'field', schema: { title: 'field', type: 'string' } },{ name: 'increment', schema: { title: 'increment', type: 'number' } }
     // mykey successfully decoded as key (string). Decoded value mykey. Tokens remaining [field,2.0e2], target args remainin count: 2
     // field successfully decoded as field (string). Decoded value field. Tokens remaining [2.0e2], target args remainin count: 1
     // 2.0e2 parsed into a bad number 200

--- a/test/generated/commands/incrbyfloat.test.ts
+++ b/test/generated/commands/incrbyfloat.test.ts
@@ -20,7 +20,7 @@ test("docs/redis-doc/commands/incrbyfloat.md example 1", async () => {
     outputs.r3 = await client.set("mykey", "5.0e3");
     // Error decoding command `INCRBYFLOAT mykey 2.0e2`:
 
-    // decoding INCRBYFLOAT overload 0 (key,increment): { name: 'key', schema: { type: 'string' } },{ name: 'increment', schema: { type: 'number' } }
+    // decoding INCRBYFLOAT overload 0 (key,increment): { name: 'key', schema: { title: 'key', type: 'string' } },{ name: 'increment', schema: { title: 'increment', type: 'number' } }
     // mykey successfully decoded as key (string). Decoded value mykey. Tokens remaining [2.0e2], target args remainin count: 1
     // 2.0e2 parsed into a bad number 200
     // ---


### PR DESCRIPTION
This applies a few improvements to how things are named, and uses the new TypeScript named tuple type feature to make complex commands which require tuple inputs more readable.

Example:
Before:
```typescript
xgroup(delconsumer_key_groupname_consumername?: ["DELCONSUMER", [string, string, string]]): Promise<unknown>;
```

After:
```typescript
xgroup(
        delconsumer?: [
            delconsumer: "DELCONSUMER",
            key_groupname_consumername: [key: string, groupname: string, consumername: string]
        ]
    ): Promise<unknown>;
```

ts34 output:
```typescript
    xgroup(delconsumer?: [
        /*delconsumer*/ "DELCONSUMER",
        /*key_groupname_consumername*/ [
            /*key*/ string,
            /*groupname*/ string,
            /*consumername*/ string
        ]
    ]): Promise<unknown>;
```


Also use downlevel-dts to produce types compatible with typescript <4.